### PR TITLE
Remove duplicate values from Feeds API. Closes #485

### DIFF
--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -258,13 +258,6 @@ def feeds_response(iocs, feed_params, valid_feed_types, dict_only=False, verbose
                     "destination_port_count": len(ioc["destination_ports"]),
                 }
 
-                if verbose and (ioc[Honeypots.LOG4J.value] or ioc[Honeypots.COWRIE.value]):
-                    data_["honeypots"] = [hp for hp in data_["honeypots"] if hp is not None]
-                    if ioc[Honeypots.LOG4J.value]:
-                        data_["honeypots"].append(Honeypots.LOG4J.value)
-                    if ioc[Honeypots.COWRIE.value]:
-                        data_["honeypots"].append(Honeypots.COWRIE.value)
-
                 if verbose:
                     json_list.append(data_)
                     continue

--- a/greedybear/cronjobs/scoring/scoring_jobs.py
+++ b/greedybear/cronjobs/scoring/scoring_jobs.py
@@ -91,11 +91,16 @@ class TrainModels(Cronjob):
 
         training_data = self.load_training_data()
         if not training_data:
-            self.log.info("no training data found, skip training")
+            self.log.warning("no training data found, skip training")
             self.save_training_data()
             return
 
-        training_date = max(row["last_seen"] for row in training_data)
+        if not isinstance(training_data[0]["feed_type"], list):
+            self.log.warning("training data outdated, skip training")
+            self.save_training_data()
+            return
+
+        training_date = max(ioc["last_seen"] for ioc in training_data)
         training_ips = {ioc["value"]: ioc["interaction_count"] for ioc in training_data}
         self.log.info(f"training data is from {training_date}, contains {len(training_data)} IoCs")
 

--- a/greedybear/cronjobs/scoring/utils.py
+++ b/greedybear/cronjobs/scoring/utils.py
@@ -81,9 +81,9 @@ def get_features(iocs: list[dict], reference_day: str) -> pd.DataFrame:
                 "asn": str(ioc["asn"]),
                 "ip_reputation": ioc["ip_reputation"],
                 # MULTI VALUE FEATURES
-                "honeypots": ioc["honeypots"],
+                "honeypots": ioc["feed_type"],
                 # NUMERICAL FEATURES
-                "honeypot_count": len(ioc["honeypots"]),
+                "honeypot_count": len(ioc["feed_type"]),
                 "destination_port_count": ioc["destination_port_count"],
                 "days_seen_count": days_seen_count,
                 "active_timespan": active_timespan,

--- a/tests/test_scoring_utils.py
+++ b/tests/test_scoring_utils.py
@@ -93,7 +93,7 @@ class TestFeatExtraction(CustomTestCase):
         self.assertEqual(str(features[0]["days_seen"][0]), today)
         self.assertEqual(features[0]["asn"], "12345")
         self.assertEqual(features[0]["ip_reputation"], "mass scanner")
-        self.assertEqual(set(features[0]["honeypots"]), set(["Heralding", "Ciscoasa", "log4j", "cowrie"]))
+        self.assertEqual(set(features[0]["honeypots"]), set(["heralding", "ciscoasa", "log4j", "cowrie"]))
         self.assertEqual(features[0]["honeypot_count"], 4)
         self.assertEqual(features[0]["destination_port_count"], 3)
         self.assertEqual(features[0]["days_seen_count"], 1)
@@ -116,7 +116,7 @@ class TestMultiLabelEncode(CustomTestCase):
         data = get_current_data()
         features = get_features(data, today)
         features = multi_label_encode(features, "honeypots").to_dict("records")
-        for h in ["Heralding", "Ciscoasa", "log4j", "cowrie"]:
+        for h in ["heralding", "ciscoasa", "log4j", "cowrie"]:
             self.assertEqual(features[0][f"has_{h}"], 1)
 
     def test_multi_label_encode_sample(self):


### PR DESCRIPTION
# Description
Removes the "honeypots" field from Feeds API.

## Related issues
#485 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
  
### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.
