### PR TITLE
Upgrade Django to 5.2. Closes #502

### DIFF
--- a/docker/default.yml
+++ b/docker/default.yml
@@ -4,7 +4,7 @@ x-no-healthcheck: &no-healthcheck
 
 services:
   postgres:
-    image: library/postgres:13-alpine
+    image: library/postgres:18-alpine
     container_name: greedybear_postgres
     volumes:
       - postgres_data:/var/lib/postgresql/data/

--- a/requirements/project-requirements.txt
+++ b/requirements/project-requirements.txt
@@ -5,7 +5,7 @@ elasticsearch-dsl==8.18.0
 
 Django==4.2.24
 djangorestframework==3.16.1
-django-rest-email-auth==4.0.3
+django-rest-email-auth==5.0.0
 django-ses==4.4.0
 
 psycopg2-binary==2.9.10

--- a/requirements/project-requirements.txt
+++ b/requirements/project-requirements.txt
@@ -3,7 +3,7 @@ celery==5.5.3
 # if you change this, update the documentation
 elasticsearch-dsl==8.18.0
 
-Django==4.2.24
+Django==5.2.7
 djangorestframework==3.16.1
 django-rest-email-auth==5.0.0
 django-ses==4.4.0


### PR DESCRIPTION
# Description
Upgrades Django to 5.2 and PostgreSQL to 18. An upgrade guide has been already committed to the docs repo:
https://github.com/intelowlproject/docs/commit/0e8a8cfdc89584b5a3fb4e63bce3dd3665b37593


## Related issues
- Closes #502 

## Type of change

Please delete options that are not relevant.
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [x] I have added documentation of the new features.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] ~~I have added tests for the feature/bug I solved.~~ All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
  
### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.
