### PR TITLE
Include mass scanners in advanced API by default. Closes #580

### DIFF
--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -33,9 +33,8 @@ def feeds(request, feed_type, attack_type, prioritize, format_):
     logger.info(f"request /api/feeds with params: feed type: {feed_type}, " f"attack_type: {attack_type}, prioritization: {prioritize}, format: {format_}")
 
     feed_params = FeedRequestParams({"feed_type": feed_type, "attack_type": attack_type, "format_": format_})
+    feed_params.default_excludes(request.query_params)
     feed_params.set_prioritization(prioritize)
-    if request.query_params and "include_mass_scanners" in request.query_params:
-        feed_params.include_mass_scanners()
 
     valid_feed_types = get_valid_feed_types()
     iocs_queryset = get_queryset(request, feed_params, valid_feed_types)
@@ -58,9 +57,8 @@ def feeds_pagination(request):
 
     feed_params = FeedRequestParams(request.query_params)
     feed_params.format = "json"
+    feed_params.default_excludes(request.query_params)
     feed_params.set_prioritization(request.query_params.get("prioritize"))
-    if request.query_params and "include_mass_scanners" in request.query_params:
-        feed_params.include_mass_scanners()
 
     valid_feed_types = get_valid_feed_types()
     iocs_queryset = get_queryset(request, feed_params, valid_feed_types)
@@ -83,8 +81,8 @@ def feeds_advanced(request):
         attack_type (str): Type of attack to filter. (supported: `scanner`, `payload_request`, `all`; default: `all`)
         max_age (int): Maximum number of days since last occurrence. E.g. an IOC that was last seen 4 days ago is excluded by default. (default: 3)
         min_days_seen (int): Minimum number of days on which an IOC must have been seen. (default: 1)
-        include_reputation (str): `;`-separated list of reputation values to include, e.g. `known attacker` or `known attacker;` to include IOCs without reputation. (default: include all) this has precedence over exclusion
-        exclude_reputation (str): `;`-separated list of reputation values to exclude, e.g. `mass scanner` or `mass scanner;bot, crawler`. (default: exclude mass scanners)
+        include_reputation (str): `;`-separated list of reputation values to include, e.g. `known attacker` or `known attacker;` to include IOCs without reputation. (default: include all)
+        exclude_reputation (str): `;`-separated list of reputation values to exclude, e.g. `mass scanner` or `mass scanner;bot, crawler`. (default: exclude none)
         feed_size (int): Number of IOC items to return. (default: 5000)
         ordering (str): Field to order results by, with optional `-` prefix for descending. (default: `-last_seen`)
         verbose (bool): `true` to include IOC properties that contain a lot of data, e.g. the list of days it was seen. (default: `false`)

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -34,7 +34,7 @@ def feeds(request, feed_type, attack_type, prioritize, format_):
     logger.info(f"request /api/feeds with params: feed type: {feed_type}, " f"attack_type: {attack_type}, prioritization: {prioritize}, format: {format_}")
 
     feed_params = FeedRequestParams({"feed_type": feed_type, "attack_type": attack_type, "format_": format_})
-    feed_params.default_excludes(request.query_params)
+    feed_params.apply_default_filters(request.query_params)
     feed_params.set_prioritization(prioritize)
 
     valid_feed_types = get_valid_feed_types()
@@ -58,7 +58,7 @@ def feeds_pagination(request):
 
     feed_params = FeedRequestParams(request.query_params)
     feed_params.format = "json"
-    feed_params.default_excludes(request.query_params)
+    feed_params.apply_default_filters(request.query_params)
     feed_params.set_prioritization(request.query_params.get("prioritize"))
 
     valid_feed_types = get_valid_feed_types()

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -26,6 +26,7 @@ def feeds(request, feed_type, attack_type, prioritize, format_):
         prioritize (str): Prioritization mechanism to use (e.g., recent, persistent).
         format_ (str): Desired format of the response (e.g., json, csv, txt).
         include_mass_scanners (bool): query parameter flag to include IOCs that are known mass scanners.
+        include_tor_exit_nodes (bool): query parameter flag to include IOCs that are known tor exit nodes.
 
     Returns:
         Response: The HTTP response with formatted IOC data.

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -94,7 +94,7 @@ class FeedRequestParams:
                     self.ordering = "-last_seen"
             case "persistent":
                 self.max_age = "14"
-                self.min_days_seen: "10"
+                self.min_days_seen = "10"
                 if "feed_type" in self.ordering:
                     self.feed_type_sorting = self.ordering
                     self.ordering = "-attack_count"

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -81,6 +81,8 @@ class FeedRequestParams:
             query_params = dict()
         if "include_mass_scanners" not in query_params:
             self.exclude_reputation.append("mass scanner")
+        if "include_tor_exit_nodes" not in query_params:
+            self.exclude_reputation.append("tor exit node")
 
     def set_prioritization(self, prioritize: str):
         match prioritize:

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -76,7 +76,7 @@ class FeedRequestParams:
         self.format = query_params.get("format_", "json").lower()
         self.feed_type_sorting = None
 
-    def default_excludes(self, query_params):
+    def apply_default_filters(self, query_params):
         if not query_params:
             query_params = dict()
         if "include_mass_scanners" not in query_params:

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -75,10 +75,12 @@ class FeedRequestParams:
         self.paginate = query_params.get("paginate", "false").lower()
         self.format = query_params.get("format_", "json").lower()
         self.feed_type_sorting = None
-        self.exclude_reputation.append("mass scanner")
 
-    def include_mass_scanners(self):
-        self.exclude_reputation.remove("mass scanner")
+    def default_excludes(self, query_params):
+        if not query_params:
+            query_params = dict()
+        if "include_mass_scanners" not in query_params:
+            self.exclude_reputation.append("mass scanner")
 
     def set_prioritization(self, prioritize: str):
         match prioritize:
@@ -155,14 +157,11 @@ def get_queryset(request, feed_params, valid_feed_types):
         query_dict["number_of_days_seen__gte"] = int(feed_params.min_days_seen)
     if feed_params.include_reputation:
         query_dict["ip_reputation__in"] = feed_params.include_reputation
-        for reputation_type in feed_params.include_reputation:
-            if reputation_type in feed_params.exclude_reputation:
-                feed_params.exclude_reputation.remove(reputation_type)
 
     iocs = (
         IOC.objects.filter(**query_dict)
         .filter(Q(cowrie=True) | Q(log4j=True) | Q(general_honeypot__active=True))
-        .exclude(Q() if "nothing" in feed_params.exclude_reputation else Q(ip_reputation__in=feed_params.exclude_reputation))
+        .exclude(ip_reputation__in=feed_params.exclude_reputation)
         .annotate(value=F("name"))
         .annotate(honeypots=ArrayAgg("general_honeypot__name"))
         .order_by(feed_params.ordering)[: int(feed_params.feed_size)]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -59,6 +59,28 @@ class CustomTestCase(TestCase):
             expected_interactions=11.1,
         )
 
+        cls.ioc_3 = IOC.objects.create(
+            name="100.100.100.100",
+            type=iocType.IP.value,
+            first_seen=cls.current_time,
+            last_seen=cls.current_time,
+            days_seen=[cls.current_time],
+            number_of_days_seen=1,
+            attack_count=1,
+            interaction_count=1,
+            log4j=False,
+            cowrie=True,
+            scanner=True,
+            payload_request=True,
+            related_urls=[],
+            ip_reputation="tor exit node",
+            asn="12345",
+            destination_ports=[22, 23, 24],
+            login_attempts=1,
+            recurrence_probability=0.1,
+            expected_interactions=11.1,
+        )
+
         cls.ioc.general_honeypot.add(cls.heralding)  # FEEDS
         cls.ioc.general_honeypot.add(cls.ciscoasa)  # FEEDS
         cls.ioc.save()

--- a/tests/test_scoring_utils.py
+++ b/tests/test_scoring_utils.py
@@ -78,7 +78,7 @@ class TestFeatExtraction(CustomTestCase):
     def test_data_retrieval(self):
         """Test with sample IoCs"""
         data = get_current_data()
-        self.assertEqual(len(data), 2)
+        self.assertEqual(len(data), 3)
 
     def test_feature_extraction(self):
         """Test with sample IoCs"""
@@ -92,8 +92,9 @@ class TestFeatExtraction(CustomTestCase):
             self.assertEqual(len(feature["days_seen"]), 1)
             self.assertEqual(str(feature["days_seen"][0]), today)
             self.assertEqual(feature["asn"], "12345")
-            self.assertEqual(set(feature["honeypots"]), set(["heralding", "ciscoasa", "log4j", "cowrie"]))
-            self.assertEqual(feature["honeypot_count"], 4)
+            self.assertTrue(len(feature["honeypots"]) > 0)
+            self.assertTrue(set(feature["honeypots"]).issubset({"heralding", "ciscoasa", "log4j", "cowrie"}))
+            self.assertEqual(feature["honeypot_count"], len(feature["honeypots"]))
             self.assertEqual(feature["destination_port_count"], 3)
             self.assertEqual(feature["days_seen_count"], 1)
             self.assertEqual(feature["active_timespan"], 1)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -95,10 +95,20 @@ class FeedsViewTestCase(CustomTestCase):
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["total_pages"], 1)
 
-    def test_200_feeds_pagination_inclusion(self):
+    def test_200_feeds_pagination_inclusion_mass(self):
         response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_mass_scanners")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 2)
+
+    def test_200_feeds_pagination_inclusion_tor(self):
+        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_tor_exit_nodes")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 2)
+
+    def test_200_feeds_pagination_inclusion_mass_and_tor(self):
+        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_mass_scanners&include_tor_exit_nodes")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 3)
 
     def test_400_feeds_pagination(self):
         response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=test&age=recent")

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -139,7 +139,7 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
     def test_200_feeds_pagination(self):
         response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["count"], 2)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_200_feeds_pagination_include(self):
@@ -148,10 +148,10 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["total_pages"], 1)
 
-    def test_200_feeds_pagination_exclude_nothing(self):
-        response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&exclude_reputation=nothing")
+    def test_200_feeds_pagination_exclude(self):
+        response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&exclude_reputation=mass%20scanner")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_400_feeds_pagination(self):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -139,7 +139,7 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
     def test_200_feeds_pagination(self):
         response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(response.json()["count"], 3)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_200_feeds_pagination_include(self):
@@ -148,10 +148,16 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["total_pages"], 1)
 
-    def test_200_feeds_pagination_exclude(self):
+    def test_200_feeds_pagination_exclude_mass(self):
         response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&exclude_reputation=mass%20scanner")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json()["count"], 1)
+        self.assertEqual(response.json()["count"], 2)
+        self.assertEqual(response.json()["total_pages"], 1)
+
+    def test_200_feeds_pagination_exclude_tor(self):
+        response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&exclude_reputation=tor%20exit%20node")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 2)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_400_feeds_pagination(self):
@@ -203,7 +209,7 @@ class StatisticsViewTestCase(CustomTestCase):
         self.assertEqual(response.json()[0]["Heralding"], 2)
         self.assertEqual(response.json()[0]["Ciscoasa"], 2)
         self.assertEqual(response.json()[0]["Log4j"], 2)
-        self.assertEqual(response.json()[0]["Cowrie"], 2)
+        self.assertEqual(response.json()[0]["Cowrie"], 3)
         self.assertEqual(response.json()[0]["Tanner"], 0)
 
 


### PR DESCRIPTION
# Description
Mass scanners were removed by default from all feed APIs in #545 . However this leads to confusing behaviour in the advanced API. Therefore the changes made in #545 are partly reverted here such that the advanced API delivers all IoCs by default.
Also the default exclusion of tor exit nodes in the "basic" feeds API is introduced here. 

## Related issues
Closes #580 
Part of #547 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [x] I have added documentation of the new features.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
  
### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.
