### PR TITLE
Solved issue #607 - Allow to query for passwords in CowrieSession API

### DIFF
--- a/greedybear/migrations/0023_add_gin_index_credentials.py
+++ b/greedybear/migrations/0023_add_gin_index_credentials.py
@@ -1,0 +1,20 @@
+from django.contrib.postgres.indexes import GinIndex
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("greedybear", "0022_whatsmyip"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="cowriesession",
+            index=GinIndex(
+                fields=["credentials"],
+                name="greedybear_credentials_gin_idx",
+            ),
+        ),
+    ]
+

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -437,6 +437,30 @@ class CowrieSessionViewTestCase(CustomTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("credentials", response.data)
 
+    # # # # # Password Query Tests # # # # #
+    def test_password_query(self):
+        """Test view with a valid password query."""
+        response = self.client.get("/api/cowrie_session?query=root&include_credentials=true")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("query", response.data)
+        self.assertEqual(response.data["query"], "root")
+        self.assertIn("credentials", response.data)
+        self.assertEqual(len(response.data["credentials"]), 1)
+        self.assertEqual(response.data["credentials"][0], "root | root")
+
+    def test_password_query_not_found(self):
+        """Test view with a password that doesn't exist."""
+        response = self.client.get("/api/cowrie_session?query=nonexistentpassword")
+        self.assertEqual(response.status_code, 404)
+
+    def test_password_query_with_session_data(self):
+        """Test password query with session data included."""
+        response = self.client.get("/api/cowrie_session?query=user&include_session_data=true")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("sessions", response.data)
+        self.assertEqual(len(response.data["sessions"]), 1)
+        self.assertEqual(response.data["sessions"][0]["credentials"][0], "user | user")
+
     # # # # # Hash Validation Tests # # # # #
     def test_nonexistent_hash(self):
         """Test that view returns 404 for nonexistent hash."""
@@ -444,9 +468,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_hash_wrong_length(self):
-        """Test that hashes with incorrect length are rejected."""
+        """Test that hashes with incorrect length are treated as password queries."""
         response = self.client.get("/api/cowrie_session?query=" + "a" * 32)  # 32 chars instead of 64
-        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.status_code, 404)
 
     def test_hash_invalid_characters(self):
         """Test that hashes with invalid characters are rejected."""


### PR DESCRIPTION
Solved #607 

# Description

This PR adds the ability to query CowrieSession API by password, in addition to the existing IP address and SHA-256 hash query methods.

## Changes Made

1. **Added password query support** to `/api/cowrie_session` endpoint:
   - Users can now query sessions by providing a password string
   - The query searches for credentials matching the pattern `" | {password}"` in the credentials array field
   - Returns 404 if no sessions are found with the specified password

2. **Added GIN index** on `CowrieSession.credentials` field:
   - Migration `0023_add_gin_index_credentials.py` creates a GIN index for efficient array searches
   - Thi improves query performance when searching through the credentials array

3. **Added input validation**:
   - Rejects 64 character strings that aren't valid SHA-256 hashes
   - Rejects strings with dots that aren't valid IP addresses

4. **Tested the functions i added**:
   - `test_password_query`: Valid password query returns correct results
   - `test_password_query_not_found`: Non-existent password returns 404
   - `test_password_query_with_session_data`: Password query with session data included

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`. (Please verify this is correct)
- [x] I have added documentation of the new features. (Updated docstring in `cowrie_session_view`)
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [x] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)). (Updated view docstring)
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.

