### PR TITLE
Fix negative predictions in Feeds API

### DIFF
--- a/greedybear/cronjobs/scoring/ml_model.py
+++ b/greedybear/cronjobs/scoring/ml_model.py
@@ -297,4 +297,5 @@ class Regressor(MLModel):
         Returns:
             np.ndarray: Array of predicted values with shape (n_samples,)
         """
-        return self.model.predict(X)
+        predictions = self.model.predict(X)
+        return np.maximum(predictions, 0)

--- a/tests/test_rf_models.py
+++ b/tests/test_rf_models.py
@@ -101,3 +101,16 @@ class TestRegressor(CustomTestCase):
 
         auc = regressor.recall_auc(df, training_target)
         self.assertEqual(0 <= auc <= 1, True)
+
+    def test_negative_predictions(self):
+        """Test that negative predictions are clipped to 0"""
+        regressor = self.MockRFRegressor()
+        regressor.model = regressor.untrained_model
+
+        # Set return value with negative numbers
+        regressor.model.predict.return_value = np.array([-10, 5, 0, -1, 2])
+
+        predictions = regressor.predict(SAMPLE_DATA)
+
+        expected = np.array([0, 5, 0, 0, 2])
+        np.testing.assert_array_equal(predictions, expected)


### PR DESCRIPTION
# Description

The `RandomForestRegressor` model could occasionally produce negative values for `expected_interactions` due to specific training data patterns (negative deltas). This caused HTTP 400 errors in the Feeds API because the field requires values >= 0.

This PR implements a fix by clipping the output of the `Regressor.predict` method to be non-negative using `np.maximum(predictions, 0)`.

A test case ([test_negative_predictions](cci:1://file:///home/opbotxd/Desktop/vscode/dev/gsoc/GreedyBear/tests/test_rf_models.py:104:4-115:60)) was added to [TestRegressor](cci:2://file:///home/opbotxd/Desktop/vscode/dev/gsoc/GreedyBear/tests/test_rf_models.py:62:0-115:60) to verify this behavior.

## Related issues
Closes #625

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.