### PR TITLE
test(cronjobs): Adding integration test for test_monitor_logs.py

### DIFF
--- a/tests/greedybear/cronjobs/only_manual/test_monitor_logs.py
+++ b/tests/greedybear/cronjobs/only_manual/test_monitor_logs.py
@@ -1,0 +1,13 @@
+from unittest.mock import patch
+from django.test import TestCase
+from greedybear.cronjobs.monitor_logs import MonitorLogs
+
+
+class MonitorLogsTestCase(TestCase):
+
+    @patch("greedybear.cronjobs.monitor_logs.send_message")
+    def test_sensors(self, mock_send_message):
+        a = MonitorLogs()
+        a.execute()
+        self.assertTrue(a.success)
+        self.assertTrue(mock_send_message.called)


### PR DESCRIPTION
Part of #653.

# Description
This PR adds an integration test for monitor_logs.py with a format similar to other tests that are written for cronjob, this pr mocks send_message to verify that the function was called.
## Related issues
Please add related issues.

## Type of change

Please delete options that are not relevant.
- [ ] New feature (non-breaking change which adds functionality).
# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
  
### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.
