### PR TITLE
Fix: Make API tests independent of result order. Closes #654

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,7 +1,8 @@
+from rest_framework.test import APIClient
+
 from api.views.utils import is_ip_address, is_sha256hash
 from greedybear.consts import FEEDS_LICENSE
 from greedybear.models import GeneralHoneypot, Statistics, viewType
-from rest_framework.test import APIClient
 
 from . import CustomTestCase
 
@@ -38,16 +39,30 @@ class EnrichmentViewTestCase(CustomTestCase):
             response.json()["ioc"]["last_seen"],
             self.ioc.last_seen.isoformat(sep="T", timespec="microseconds"),
         )
-        self.assertEqual(response.json()["ioc"]["number_of_days_seen"], self.ioc.number_of_days_seen)
+        self.assertEqual(
+            response.json()["ioc"]["number_of_days_seen"], self.ioc.number_of_days_seen
+        )
         self.assertEqual(response.json()["ioc"]["attack_count"], self.ioc.attack_count)
         self.assertEqual(response.json()["ioc"]["log4j"], self.ioc.log4j)
         self.assertEqual(response.json()["ioc"]["cowrie"], self.ioc.cowrie)
-        self.assertEqual(response.json()["ioc"]["general_honeypot"][0], self.heralding.name)  # FEEDS
-        self.assertEqual(response.json()["ioc"]["general_honeypot"][1], self.ciscoasa.name)  # FEEDS
+        self.assertEqual(
+            response.json()["ioc"]["general_honeypot"][0], self.heralding.name
+        )  # FEEDS
+        self.assertEqual(
+            response.json()["ioc"]["general_honeypot"][1], self.ciscoasa.name
+        )  # FEEDS
         self.assertEqual(response.json()["ioc"]["scanner"], self.ioc.scanner)
-        self.assertEqual(response.json()["ioc"]["payload_request"], self.ioc.payload_request)
-        self.assertEqual(response.json()["ioc"]["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(response.json()["ioc"]["expected_interactions"], self.ioc.expected_interactions)
+        self.assertEqual(
+            response.json()["ioc"]["payload_request"], self.ioc.payload_request
+        )
+        self.assertEqual(
+            response.json()["ioc"]["recurrence_probability"],
+            self.ioc.recurrence_probability,
+        )
+        self.assertEqual(
+            response.json()["ioc"]["expected_interactions"],
+            self.ioc.expected_interactions,
+        )
 
     def test_for_invalid_authentication(self):
         """Check for a invalid authentication"""
@@ -61,26 +76,50 @@ class FeedsViewTestCase(CustomTestCase):
         response = self.client.get("/api/feeds/all/all/recent.json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["license"], FEEDS_LICENSE)
-        self.assertEqual(response.json()["iocs"][0]["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"])
-        self.assertEqual(response.json()["iocs"][0]["attack_count"], 1)
-        self.assertEqual(response.json()["iocs"][0]["scanner"], True)
-        self.assertEqual(response.json()["iocs"][0]["payload_request"], True)
-        self.assertEqual(response.json()["iocs"][0]["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(response.json()["iocs"][0]["expected_interactions"], self.ioc.expected_interactions)
+
+        iocs = response.json()["iocs"]
+        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+        self.assertIsNotNone(target_ioc, f"IOC {self.ioc.name} not found in response")
+
+        self.assertEqual(
+            target_ioc["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"]
+        )
+        self.assertEqual(target_ioc["attack_count"], 1)
+        self.assertEqual(target_ioc["scanner"], True)
+        self.assertEqual(target_ioc["payload_request"], True)
+        self.assertEqual(
+            target_ioc["recurrence_probability"], self.ioc.recurrence_probability
+        )
+        self.assertEqual(
+            target_ioc["expected_interactions"], self.ioc.expected_interactions
+        )
 
     def test_200_general_feeds(self):
         response = self.client.get("/api/feeds/heralding/all/recent.json")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["license"], FEEDS_LICENSE)
-        self.assertEqual(response.json()["iocs"][0]["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"])
-        self.assertEqual(response.json()["iocs"][0]["attack_count"], 1)
-        self.assertEqual(response.json()["iocs"][0]["scanner"], True)
-        self.assertEqual(response.json()["iocs"][0]["payload_request"], True)
-        self.assertEqual(response.json()["iocs"][0]["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(response.json()["iocs"][0]["expected_interactions"], self.ioc.expected_interactions)
+
+        iocs = response.json()["iocs"]
+        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+        self.assertIsNotNone(target_ioc, f"IOC {self.ioc.name} not found in response")
+
+        self.assertEqual(
+            target_ioc["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"]
+        )
+        self.assertEqual(target_ioc["attack_count"], 1)
+        self.assertEqual(target_ioc["scanner"], True)
+        self.assertEqual(target_ioc["payload_request"], True)
+        self.assertEqual(
+            target_ioc["recurrence_probability"], self.ioc.recurrence_probability
+        )
+        self.assertEqual(
+            target_ioc["expected_interactions"], self.ioc.expected_interactions
+        )
 
     def test_200_feeds_scanner_inclusion(self):
-        response = self.client.get("/api/feeds/heralding/all/recent.json?include_mass_scanners")
+        response = self.client.get(
+            "/api/feeds/heralding/all/recent.json?include_mass_scanners"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["license"], FEEDS_LICENSE)
         self.assertEqual(len(response.json()["iocs"]), 2)
@@ -90,28 +129,38 @@ class FeedsViewTestCase(CustomTestCase):
         self.assertEqual(response.status_code, 400)
 
     def test_200_feeds_pagination(self):
-        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent")
+        response = self.client.get(
+            "/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_200_feeds_pagination_inclusion_mass(self):
-        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_mass_scanners")
+        response = self.client.get(
+            "/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_mass_scanners"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 2)
 
     def test_200_feeds_pagination_inclusion_tor(self):
-        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_tor_exit_nodes")
+        response = self.client.get(
+            "/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_tor_exit_nodes"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 2)
 
     def test_200_feeds_pagination_inclusion_mass_and_tor(self):
-        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_mass_scanners&include_tor_exit_nodes")
+        response = self.client.get(
+            "/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&include_mass_scanners&include_tor_exit_nodes"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 3)
 
     def test_400_feeds_pagination(self):
-        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=test&age=recent")
+        response = self.client.get(
+            "/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=test&age=recent"
+        )
         self.assertEqual(response.status_code, 400)
 
 
@@ -124,54 +173,88 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         response = self.client.get("/api/feeds/advanced/")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["license"], FEEDS_LICENSE)
-        self.assertEqual(response.json()["iocs"][0]["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"])
-        self.assertEqual(response.json()["iocs"][0]["attack_count"], 1)
-        self.assertEqual(response.json()["iocs"][0]["scanner"], True)
-        self.assertEqual(response.json()["iocs"][0]["payload_request"], True)
-        self.assertEqual(response.json()["iocs"][0]["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(response.json()["iocs"][0]["expected_interactions"], self.ioc.expected_interactions)
+
+        # FIX: Find specific IOC by value (IP)
+        iocs = response.json()["iocs"]
+        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+        self.assertIsNotNone(target_ioc, f"IOC {self.ioc.name} not found in response")
+
+        self.assertEqual(
+            target_ioc["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"]
+        )
+        self.assertEqual(target_ioc["attack_count"], 1)
+        self.assertEqual(target_ioc["scanner"], True)
+        self.assertEqual(target_ioc["payload_request"], True)
+        self.assertEqual(
+            target_ioc["recurrence_probability"], self.ioc.recurrence_probability
+        )
+        self.assertEqual(
+            target_ioc["expected_interactions"], self.ioc.expected_interactions
+        )
 
     def test_200_general_feeds(self):
         response = self.client.get("/api/feeds/advanced/?feed_type=heralding")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["license"], FEEDS_LICENSE)
-        self.assertEqual(response.json()["iocs"][0]["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"])
-        self.assertEqual(response.json()["iocs"][0]["attack_count"], 1)
-        self.assertEqual(response.json()["iocs"][0]["scanner"], True)
-        self.assertEqual(response.json()["iocs"][0]["payload_request"], True)
-        self.assertEqual(response.json()["iocs"][0]["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(response.json()["iocs"][0]["expected_interactions"], self.ioc.expected_interactions)
+
+        # FIX: Find specific IOC by value (IP)
+        iocs = response.json()["iocs"]
+        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+        self.assertIsNotNone(target_ioc, f"IOC {self.ioc.name} not found in response")
+
+        self.assertEqual(
+            target_ioc["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"]
+        )
+        self.assertEqual(target_ioc["attack_count"], 1)
+        self.assertEqual(target_ioc["scanner"], True)
+        self.assertEqual(target_ioc["payload_request"], True)
+        self.assertEqual(
+            target_ioc["recurrence_probability"], self.ioc.recurrence_probability
+        )
+        self.assertEqual(
+            target_ioc["expected_interactions"], self.ioc.expected_interactions
+        )
 
     def test_400_feeds(self):
         response = self.client.get("/api/feeds/advanced/?attack_type=test")
         self.assertEqual(response.status_code, 400)
 
     def test_200_feeds_pagination(self):
-        response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1")
+        response = self.client.get(
+            "/api/feeds/advanced/?paginate=true&page_size=10&page=1"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 3)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_200_feeds_pagination_include(self):
-        response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&include_reputation=mass%20scanner")
+        response = self.client.get(
+            "/api/feeds/advanced/?paginate=true&page_size=10&page=1&include_reputation=mass%20scanner"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 1)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_200_feeds_pagination_exclude_mass(self):
-        response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&exclude_reputation=mass%20scanner")
+        response = self.client.get(
+            "/api/feeds/advanced/?paginate=true&page_size=10&page=1&exclude_reputation=mass%20scanner"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 2)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_200_feeds_pagination_exclude_tor(self):
-        response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&exclude_reputation=tor%20exit%20node")
+        response = self.client.get(
+            "/api/feeds/advanced/?paginate=true&page_size=10&page=1&exclude_reputation=tor%20exit%20node"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["count"], 2)
         self.assertEqual(response.json()["total_pages"], 1)
 
     def test_400_feeds_pagination(self):
-        response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&attack_type=test")
+        response = self.client.get(
+            "/api/feeds/advanced/?paginate=true&page_size=10&page=1&attack_type=test"
+        )
         self.assertEqual(response.status_code, 400)
 
 
@@ -180,8 +263,12 @@ class StatisticsViewTestCase(CustomTestCase):
     def setUpClass(self):
         super(StatisticsViewTestCase, self).setUpClass()
         Statistics.objects.all().delete()
-        Statistics.objects.create(source="140.246.171.141", view=viewType.FEEDS_VIEW.value)
-        Statistics.objects.create(source="140.246.171.141", view=viewType.ENRICHMENT_VIEW.value)
+        Statistics.objects.create(
+            source="140.246.171.141", view=viewType.FEEDS_VIEW.value
+        )
+        Statistics.objects.create(
+            source="140.246.171.141", view=viewType.ENRICHMENT_VIEW.value
+        )
 
     @classmethod
     def tearDownClass(self):
@@ -226,19 +313,18 @@ class StatisticsViewTestCase(CustomTestCase):
 class GeneralHoneypotViewTestCase(CustomTestCase):
     def test_200_all_general_honeypots(self):
         self.assertEqual(GeneralHoneypot.objects.count(), 2)
-        # add a general honeypot not active
         GeneralHoneypot(name="Adbhoney", active=False).save()
         self.assertEqual(GeneralHoneypot.objects.count(), 3)
 
         response = self.client.get("/api/general_honeypot")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), ["Heralding", "Ciscoasa", "Adbhoney"])
+        self.assertCountEqual(response.json(), ["Heralding", "Ciscoasa", "Adbhoney"])
 
     def test_200_active_general_honeypots(self):
         self.assertEqual(GeneralHoneypot.objects.count(), 2)
         response = self.client.get("/api/general_honeypot?onlyActive=true")
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), ["Heralding", "Ciscoasa"])
+        self.assertCountEqual(response.json(), ["Heralding", "Ciscoasa"])
 
 
 class CommandSequenceViewTestCase(CustomTestCase):
@@ -268,7 +354,9 @@ class CommandSequenceViewTestCase(CustomTestCase):
 
     def test_ip_address_query_with_similar(self):
         """Test view with a valid IP address query including similar sequences."""
-        response = self.client.get("/api/command_sequence?query=140.246.171.141&include_similar")
+        response = self.client.get(
+            "/api/command_sequence?query=140.246.171.141&include_similar"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("executed_commands", response.data)
         self.assertIn("executed_by", response.data)
@@ -287,7 +375,9 @@ class CommandSequenceViewTestCase(CustomTestCase):
 
     def test_hash_query_with_similar(self):
         """Test view with a valid hash query including similar sequences."""
-        response = self.client.get(f"/api/command_sequence?query={self.hash}&include_similar")
+        response = self.client.get(
+            f"/api/command_sequence?query={self.hash}&include_similar"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("commands", response.data)
         self.assertIn("iocs", response.data)
@@ -319,7 +409,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_ip_address_query_with_similar(self):
         """Test view with a valid IP address query including similar sequences."""
-        response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_similar=true")
+        response = self.client.get(
+            "/api/cowrie_session?query=140.246.171.141&include_similar=true"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("query", response.data)
         self.assertIn("commands", response.data)
@@ -330,7 +422,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_ip_address_query_with_credentials(self):
         """Test view with a valid IP address query including credentials."""
-        response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_credentials=true")
+        response = self.client.get(
+            "/api/cowrie_session?query=140.246.171.141&include_credentials=true"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("query", response.data)
         self.assertIn("commands", response.data)
@@ -342,7 +436,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_ip_address_query_with_sessions(self):
         """Test view with a valid IP address query including session data."""
-        response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_session_data=true")
+        response = self.client.get(
+            "/api/cowrie_session?query=140.246.171.141&include_session_data=true"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("query", response.data)
         self.assertIn("commands", response.data)
@@ -359,7 +455,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_ip_address_query_with_all(self):
         """Test view with a valid IP address query including everything."""
-        response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_similar=true&include_credentials=true&include_session_data=true")
+        response = self.client.get(
+            "/api/cowrie_session?query=140.246.171.141&include_similar=true&include_credentials=true&include_session_data=true"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("query", response.data)
         self.assertIn("commands", response.data)
@@ -380,7 +478,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_hash_query_with_all(self):
         """Test view with a valid hash query including everything."""
-        response = self.client.get(f"/api/cowrie_session?query={self.hash}&include_similar=true&include_credentials=true&include_session_data=true")
+        response = self.client.get(
+            f"/api/cowrie_session?query={self.hash}&include_similar=true&include_credentials=true&include_session_data=true"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("query", response.data)
         self.assertIn("commands", response.data)
@@ -423,17 +523,23 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_include_credentials_invalid_value(self):
         """Test that invalid boolean values default to false."""
-        response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_credentials=maybe")
+        response = self.client.get(
+            "/api/cowrie_session?query=140.246.171.141&include_credentials=maybe"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertNotIn("credentials", response.data)
 
     def test_case_insensitive_boolean_parameters(self):
         """Test that boolean parameters accept various case formats."""
-        response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_credentials=TRUE")
+        response = self.client.get(
+            "/api/cowrie_session?query=140.246.171.141&include_credentials=TRUE"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("credentials", response.data)
 
-        response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_credentials=True")
+        response = self.client.get(
+            "/api/cowrie_session?query=140.246.171.141&include_credentials=True"
+        )
         self.assertEqual(response.status_code, 200)
         self.assertIn("credentials", response.data)
 
@@ -445,7 +551,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_hash_wrong_length(self):
         """Test that hashes with incorrect length are rejected."""
-        response = self.client.get("/api/cowrie_session?query=" + "a" * 32)  # 32 chars instead of 64
+        response = self.client.get(
+            "/api/cowrie_session?query=" + "a" * 32
+        )  # 32 chars instead of 64
         self.assertEqual(response.status_code, 400)
 
     def test_hash_invalid_characters(self):
@@ -456,8 +564,12 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_hash_case_insensitive(self):
         """Test that hash queries are case-insensitive."""
-        response_lower = self.client.get(f"/api/cowrie_session?query={self.hash.lower()}")
-        response_upper = self.client.get(f"/api/cowrie_session?query={self.hash.upper()}")
+        response_lower = self.client.get(
+            f"/api/cowrie_session?query={self.hash.lower()}"
+        )
+        response_upper = self.client.get(
+            f"/api/cowrie_session?query={self.hash.upper()}"
+        )
         self.assertEqual(response_lower.status_code, response_upper.status_code)
 
     # # # # # Special Characters & Encoding Tests # # # # #
@@ -469,7 +581,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
 
     def test_query_with_special_characters(self):
         """Test handling of queries with special characters."""
-        response = self.client.get("/api/cowrie_session?query=<script>alert('xss')</script>")
+        response = self.client.get(
+            "/api/cowrie_session?query=<script>alert('xss')</script>"
+        )
         self.assertEqual(response.status_code, 400)
 
     # # # # # Authentication & Authorization Tests # # # # #


### PR DESCRIPTION

Description
This PR addresses the test flakiness reported in issue #654, where API tests depended on the specific order of results returned by the database.

Changes made:

Dynamic Lookup: In FeedsViewTestCase and FeedsAdvancedViewTestCase (within tests/test_views.py), I replaced the hardcoded index [0] with a generator expression (next(...)). This allows the test to dynamically find the specific IoC by its value (IP address) regardless of its position in the response list.

Order-Agnostic Comparison: In GeneralHoneypotViewTestCase, I replaced assertEqual with assertCountEqual for list comparisons. This ensures the tests pass as long as the correct items are present, ignoring their order.

Related issues
Closes #654

Type of change
[x] Bug fix (non-breaking change which fixes an issue).

[ ] New feature (non-breaking change which adds functionality).

[ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

Checklist
[x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.

[x] The pull request is for the branch develop (or main depending on repository default).

[x] I have added documentation of the new features. (N/A - Test fix only)

[x] Linters (Black, Flake, Isort) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.

[x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.

[x] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).

[ ] If the GUI has been modified:

- [ ] I have a provided a screenshot of the result in the PR.

- [ ] I have created new frontend tests for the new component or updated existing ones.