### PR TITLE
Fix order-dependent assertions in feeds tests. Closes #654

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -40,8 +40,10 @@ class EnrichmentViewTestCase(CustomTestCase):
             response.json()["ioc"]["last_seen"],
             self.ioc.last_seen.isoformat(sep="T", timespec="microseconds"),
         )
-        self.assertEqual(response.json()["ioc"]["number_of_days_seen"], self.ioc.number_of_days_seen)
-        self.assertEqual(response.json()["ioc"]["attack_count"], self.ioc.attack_count)
+        self.assertCountEqual(
+            response.json()["ioc"]["general_honeypot"],
+            [self.heralding.name, self.ciscoasa.name],
+        )
         self.assertEqual(response.json()["ioc"]["log4j"], self.ioc.log4j)
         self.assertEqual(response.json()["ioc"]["cowrie"], self.ioc.cowrie)
         self.assertEqual(response.json()["ioc"]["general_honeypot"][0], self.heralding.name)  # FEEDS
@@ -74,15 +76,29 @@ class FeedsViewTestCase(CustomTestCase):
             self.assertNotIn("license", response.json())
 
         iocs = response.json()["iocs"]
-        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
-        self.assertIsNotNone(target_ioc)
+        expected_feeds = {"log4j", "cowrie", "heralding", "ciscoasa"}
 
-        self.assertEqual(target_ioc["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"])
+        target_ioc = next(
+            (i for i in iocs if i.get("value") == self.ioc.name and set(i.get("feed_type", [])) == expected_feeds),
+            None,
+        )
+
+        self.assertIsNotNone(
+            target_ioc,
+            f"IOC {self.ioc.name} with expected feeds not found",
+        )
+
         self.assertEqual(target_ioc["attack_count"], 1)
-        self.assertEqual(target_ioc["scanner"], True)
-        self.assertEqual(target_ioc["payload_request"], True)
-        self.assertEqual(target_ioc["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(target_ioc["expected_interactions"], self.ioc.expected_interactions)
+        self.assertTrue(target_ioc["scanner"])
+        self.assertTrue(target_ioc["payload_request"])
+        self.assertEqual(
+            target_ioc["recurrence_probability"],
+            self.ioc.recurrence_probability,
+        )
+        self.assertEqual(
+            target_ioc["expected_interactions"],
+            self.ioc.expected_interactions,
+        )
 
     @override_settings(FEEDS_LICENSE="https://example.com/license")
     def test_200_all_feeds_with_license(self):
@@ -108,15 +124,29 @@ class FeedsViewTestCase(CustomTestCase):
             self.assertNotIn("license", response.json())
 
         iocs = response.json()["iocs"]
-        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
-        self.assertIsNotNone(target_ioc)
+        expected_feeds = {"log4j", "cowrie", "heralding", "ciscoasa"}
 
-        self.assertEqual(target_ioc["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"])
+        target_ioc = next(
+            (i for i in iocs if i.get("value") == self.ioc.name and set(i.get("feed_type", [])) == expected_feeds),
+            None,
+        )
+
+        self.assertIsNotNone(
+            target_ioc,
+            f"IOC {self.ioc.name} with expected feeds not found",
+        )
+
         self.assertEqual(target_ioc["attack_count"], 1)
-        self.assertEqual(target_ioc["scanner"], True)
-        self.assertEqual(target_ioc["payload_request"], True)
-        self.assertEqual(target_ioc["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(target_ioc["expected_interactions"], self.ioc.expected_interactions)
+        self.assertTrue(target_ioc["scanner"])
+        self.assertTrue(target_ioc["payload_request"])
+        self.assertEqual(
+            target_ioc["recurrence_probability"],
+            self.ioc.recurrence_probability,
+        )
+        self.assertEqual(
+            target_ioc["expected_interactions"],
+            self.ioc.expected_interactions,
+        )
 
     def test_200_feeds_scanner_inclusion(self):
         response = self.client.get("/api/feeds/heralding/all/recent.json?include_mass_scanners")
@@ -203,15 +233,29 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
             self.assertNotIn("license", response.json())
 
         iocs = response.json()["iocs"]
-        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
-        self.assertIsNotNone(target_ioc)
+        expected_feeds = {"log4j", "cowrie", "heralding", "ciscoasa"}
 
-        self.assertEqual(target_ioc["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"])
+        target_ioc = next(
+            (i for i in iocs if i.get("value") == self.ioc.name and set(i.get("feed_type", [])) == expected_feeds),
+            None,
+        )
+
+        self.assertIsNotNone(
+            target_ioc,
+            f"IOC {self.ioc.name} with expected feeds not found",
+        )
+
         self.assertEqual(target_ioc["attack_count"], 1)
-        self.assertEqual(target_ioc["scanner"], True)
-        self.assertEqual(target_ioc["payload_request"], True)
-        self.assertEqual(target_ioc["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(target_ioc["expected_interactions"], self.ioc.expected_interactions)
+        self.assertTrue(target_ioc["scanner"])
+        self.assertTrue(target_ioc["payload_request"])
+        self.assertEqual(
+            target_ioc["recurrence_probability"],
+            self.ioc.recurrence_probability,
+        )
+        self.assertEqual(
+            target_ioc["expected_interactions"],
+            self.ioc.expected_interactions,
+        )
 
     def test_200_general_feeds(self):
         response = self.client.get("/api/feeds/advanced/?feed_type=heralding")
@@ -222,15 +266,29 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
             self.assertNotIn("license", response.json())
 
         iocs = response.json()["iocs"]
-        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
-        self.assertIsNotNone(target_ioc)
+        expected_feeds = {"log4j", "cowrie", "heralding", "ciscoasa"}
 
-        self.assertEqual(target_ioc["feed_type"], ["log4j", "cowrie", "heralding", "ciscoasa"])
+        target_ioc = next(
+            (i for i in iocs if i.get("value") == self.ioc.name and set(i.get("feed_type", [])) == expected_feeds),
+            None,
+        )
+
+        self.assertIsNotNone(
+            target_ioc,
+            f"IOC {self.ioc.name} with expected feeds not found",
+        )
+
         self.assertEqual(target_ioc["attack_count"], 1)
-        self.assertEqual(target_ioc["scanner"], True)
-        self.assertEqual(target_ioc["payload_request"], True)
-        self.assertEqual(target_ioc["recurrence_probability"], self.ioc.recurrence_probability)
-        self.assertEqual(target_ioc["expected_interactions"], self.ioc.expected_interactions)
+        self.assertTrue(target_ioc["scanner"])
+        self.assertTrue(target_ioc["payload_request"])
+        self.assertEqual(
+            target_ioc["recurrence_probability"],
+            self.ioc.recurrence_probability,
+        )
+        self.assertEqual(
+            target_ioc["expected_interactions"],
+            self.ioc.expected_interactions,
+        )
 
     def test_400_feeds(self):
         response = self.client.get("/api/feeds/advanced/?attack_type=test")


### PR DESCRIPTION
(Please add to the PR name the issue/s that this PR would close if merged by using a [Github](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) keyword. Example: `<feature name>. Closes #999`. If your PR is made by a single commit, please add that clause in the commit too. This is all required to automate the closure of related issues.)

# Description

This PR fixes flaky feeds-related tests by removing assumptions about response ordering.

Tests now locate IOCs using content-based predicates and compare unordered collections in an order-independent way, preventing failures caused by non-deterministic queryset ordering.


## Related issues
Closes #654

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [x] I have added documentation of the new features.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
  
### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.
