### PR TITLE
feat(tests): add comprehensive tests for cleanup.py. Closes #699

### DIFF
--- a/tests/greedybear/cronjobs/test_cleanup.py
+++ b/tests/greedybear/cronjobs/test_cleanup.py
@@ -1,12 +1,12 @@
 from datetime import datetime, timedelta
-from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from greedybear.cronjobs.cleanup import CleanUp
 from greedybear.cronjobs.repositories import CowrieSessionRepository, IocRepository
+from tests import CustomTestCase
 
 
-class TestCleanUp(TestCase):
+class TestCleanUp(CustomTestCase):
     def test_init_uses_default_repos(self):
         """Test that the CleanUp job initializes with default repositories if none are provided."""
         cleanup_job = CleanUp()
@@ -45,7 +45,9 @@ class TestCleanUp(TestCase):
         expected_ioc_date = datetime.now() - timedelta(days=100)
         # Check that the date passed is approximately correct (within 1 second)
         args, _ = ioc_repo.delete_old_iocs.call_args
-        self.assertAlmostEqual(args[0], expected_ioc_date, delta=timedelta(seconds=1))
+        actual_date = args[0]
+        time_diff = abs((actual_date - expected_ioc_date).total_seconds())
+        self.assertLess(time_diff, 1, f"Date difference ({time_diff}s) exceeds 1 second tolerance")
 
         # Verify interactions with CowrieSessionRepository
 
@@ -53,7 +55,9 @@ class TestCleanUp(TestCase):
         cowrie_repo.delete_old_command_sequences.assert_called_once()
         expected_cmd_date = datetime.now() - timedelta(days=90)
         args, _ = cowrie_repo.delete_old_command_sequences.call_args
-        self.assertAlmostEqual(args[0], expected_cmd_date, delta=timedelta(seconds=1))
+        actual_date = args[0]
+        time_diff = abs((actual_date - expected_cmd_date).total_seconds())
+        self.assertLess(time_diff, 1, f"Date difference ({time_diff}s) exceeds 1 second tolerance")
 
         # 2. delete_incomplete_sessions
         cowrie_repo.delete_incomplete_sessions.assert_called_once()
@@ -62,13 +66,17 @@ class TestCleanUp(TestCase):
         cowrie_repo.delete_sessions_without_login.assert_called_once()
         expected_session_login_date = datetime.now() - timedelta(days=30)
         args, _ = cowrie_repo.delete_sessions_without_login.call_args
-        self.assertAlmostEqual(args[0], expected_session_login_date, delta=timedelta(seconds=1))
+        actual_date = args[0]
+        time_diff = abs((actual_date - expected_session_login_date).total_seconds())
+        self.assertLess(time_diff, 1, f"Date difference ({time_diff}s) exceeds 1 second tolerance")
 
         # 4. delete_sessions_without_commands
         cowrie_repo.delete_sessions_without_commands.assert_called_once()
         expected_session_cmd_date = datetime.now() - timedelta(days=80)
         args, _ = cowrie_repo.delete_sessions_without_commands.call_args
-        self.assertAlmostEqual(args[0], expected_session_cmd_date, delta=timedelta(seconds=1))
+        actual_date = args[0]
+        time_diff = abs((actual_date - expected_session_cmd_date).total_seconds())
+        self.assertLess(time_diff, 1, f"Date difference ({time_diff}s) exceeds 1 second tolerance")
 
         # Verify logging messages
         # We expect 5 pairs of logs (start + result)


### PR DESCRIPTION
# Description

This PR implements comprehensive unit tests for [greedybear/cronjobs/cleanup.py](cci:7://file:///home/opbotxd/Desktop/vscode/dev/gsoc/honeynet/GreedyBear/greedybear/cronjobs/cleanup.py:0:0-0:0) as requested in issue #699. This logic was previously untested.

The tests ensure that the cleanup job correctly:
- Initializes with default or injected repositories.
- Calcluates the correct expiration dates for IOCs, Cowrie Sessions, and Command Sequences based on settings.
- Calls the appropriate deletion methods on the [IocRepository](cci:2://file:///home/opbotxd/Desktop/vscode/dev/gsoc/honeynet/GreedyBear/tests/test_ioc_repository.py:11:0-406:63) and [CowrieSessionRepository](cci:2://file:///home/opbotxd/Desktop/vscode/dev/gsoc/honeynet/GreedyBear/tests/test_cowrie_session_repository.py:10:0-102:13) with those dates.
- Handles edge cases like zero deletions correctly.

## Related issues
Closes #699

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.

### Code Coverage Report
Ran tests for `greedybear/cronjobs/cleanup.py`:
```text
Name                             Stmts   Miss  Cover
----------------------------------------------------
greedybear/cronjobs/cleanup.py      29      0   100%
----------------------------------------------------
TOTAL                               29      0   100%