### PR TITLE
Adding comprehensive tests for WhatsMyIPCron. Closes #708.

### DIFF
--- a/tests/greedybear/cronjobs/only_manual/test_whatsmyip.py
+++ b/tests/greedybear/cronjobs/only_manual/test_whatsmyip.py
@@ -1,0 +1,147 @@
+# This file is a part of GreedyBear https://github.com/honeynet/GreedyBear
+# See the file 'LICENSE' for copying permission.
+
+from unittest import TestCase
+from unittest.mock import patch, MagicMock
+
+from greedybear.cronjobs import whatsmyip
+from greedybear.models import IOC, WhatsMyIP
+
+
+class WhatsMyIPTestCase(TestCase):
+    """Test WhatsMyIPCron cronjob"""
+
+    def setUp(self):
+        """Set up test data"""
+        # Clean up any existing test data
+        WhatsMyIP.objects.all().delete()
+        IOC.objects.all().delete()
+
+    def tearDown(self):
+        """Clean up after tests"""
+        WhatsMyIP.objects.all().delete()
+        IOC.objects.all().delete()
+
+    @patch("greedybear.cronjobs.whatsmyip.requests.get")
+    def test_add_new_domains(self, mock_get):
+        """Test adding new domains from MISP warning list"""
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "list": ["test-domain-1.com", "test-domain-2.com"]
+        }
+        mock_get.return_value = mock_response
+
+        # Run the cronjob
+        cron = whatsmyip.WhatsMyIPCron()
+        cron.run()
+
+        # Verify domains were added
+        self.assertEqual(WhatsMyIP.objects.count(), 2)
+        self.assertTrue(
+            WhatsMyIP.objects.filter(domain="test-domain-1.com").exists()
+        )
+        self.assertTrue(
+            WhatsMyIP.objects.filter(domain="test-domain-2.com").exists()
+        )
+
+    @patch("greedybear.cronjobs.whatsmyip.requests.get")
+    def test_skip_existing_domains(self, mock_get):
+        """Test that existing domains are skipped"""
+        # Add an existing domain
+        existing_domain = WhatsMyIP.objects.create(domain="existing-domain.com")
+
+        # Mock the HTTP response with existing and new domains
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "list": ["existing-domain.com", "new-domain.com"]
+        }
+        mock_get.return_value = mock_response
+
+        # Run the cronjob
+        cron = whatsmyip.WhatsMyIPCron()
+        cron.run()
+
+        # Verify only new domain was added
+        self.assertEqual(WhatsMyIP.objects.count(), 2)
+        self.assertEqual(
+            WhatsMyIP.objects.get(domain="existing-domain.com").id, existing_domain.id
+        )
+        self.assertTrue(
+            WhatsMyIP.objects.filter(domain="new-domain.com").exists()
+        )
+
+    @patch("greedybear.cronjobs.whatsmyip.requests.get")
+    def test_remove_old_ioc_records(self, mock_get):
+        """Test that old IOC records are cleaned up"""
+        # Create an IOC record for a domain
+        domain_name = "cleanup-domain.com"
+        ioc = IOC.objects.create(name=domain_name)
+
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"list": [domain_name]}
+        mock_get.return_value = mock_response
+
+        # Run the cronjob
+        cron = whatsmyip.WhatsMyIPCron()
+        cron.run()
+
+        # Verify IOC record was deleted
+        self.assertFalse(IOC.objects.filter(id=ioc.id).exists())
+        self.assertTrue(
+            WhatsMyIP.objects.filter(domain=domain_name).exists()
+        )
+
+    @patch("greedybear.cronjobs.whatsmyip.requests.get")
+    def test_handle_missing_ioc_gracefully(self, mock_get):
+        """Test that missing IOC records don't cause errors"""
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"list": ["domain-with-no-ioc.com"]}
+        mock_get.return_value = mock_response
+
+        # Run the cronjob - should not raise exception
+        cron = whatsmyip.WhatsMyIPCron()
+        cron.run()
+
+        # Verify domain was added
+        self.assertTrue(
+            WhatsMyIP.objects.filter(domain="domain-with-no-ioc.com").exists()
+        )
+
+    @patch("greedybear.cronjobs.whatsmyip.requests.get")
+    def test_empty_domain_list(self, mock_get):
+        """Test handling of empty domain list"""
+        # Mock the HTTP response with empty list
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"list": []}
+        mock_get.return_value = mock_response
+
+        # Run the cronjob
+        cron = whatsmyip.WhatsMyIPCron()
+        cron.run()
+
+        # Verify no domains were added
+        self.assertEqual(WhatsMyIP.objects.count(), 0)
+
+    @patch("greedybear.cronjobs.whatsmyip.requests.get")
+    def test_http_request_parameters(self, mock_get):
+        """Test that HTTP request is made with correct parameters"""
+        # Mock the HTTP response
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"list": []}
+        mock_get.return_value = mock_response
+
+        # Run the cronjob
+        cron = whatsmyip.WhatsMyIPCron()
+        cron.run()
+
+        # Verify the request was made correctly
+        mock_get.assert_called_once()
+        call_args = mock_get.call_args
+        self.assertIn(
+            "https://raw.githubusercontent.com/MISP/misp-warninglists",
+            call_args[0][0],
+        )
+        self.assertEqual(call_args[1]["timeout"], 10)


### PR DESCRIPTION
This PR adds comprehensive unit tests for the WhatsMyIPCron cronjob class. Implemented 6 test cases covering:
- Adding new domains from MISP warning list
- Skipping existing domains (avoiding duplicates)
- Removing old IOC records
- Handling missing IOC records gracefully
- Testing empty domain lists
- Verifying HTTP request parameters
All tests follow existing test patterns in the codebase. Feedback needed.