### PR TITLE
Standardize test base class inheritance. Closes #700

### DIFF
--- a/tests/greedybear/cronjobs/test_monitor_logs.py
+++ b/tests/greedybear/cronjobs/test_monitor_logs.py
@@ -1,11 +1,11 @@
 from datetime import datetime, timedelta
-from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from greedybear.cronjobs.monitor_logs import MonitorLogs
+from tests import CustomTestCase
 
 
-class MonitorLogsTestCase(TestCase):
+class MonitorLogsTestCase(CustomTestCase):
     @patch("greedybear.cronjobs.monitor_logs.send_ntfy_message")
     @patch("greedybear.cronjobs.monitor_logs.send_slack_message")
     @patch("greedybear.cronjobs.monitor_logs.Path.exists")

--- a/tests/test_cowrie_extraction.py
+++ b/tests/test_cowrie_extraction.py
@@ -2,7 +2,6 @@
 Tests for Cowrie extraction helper functions and strategy.
 """
 
-from unittest import TestCase
 from unittest.mock import MagicMock, Mock, patch
 
 from greedybear.cronjobs.extraction.strategies.cowrie import (
@@ -12,9 +11,10 @@ from greedybear.cronjobs.extraction.strategies.cowrie import (
     parse_url_hostname,
 )
 from greedybear.models import CommandSequence
+from tests import ExtractionTestCase
 
 
-class TestHelperFunctions(TestCase):
+class TestHelperFunctions(ExtractionTestCase):
     """Test standalone helper functions."""
 
     def test_parse_url_hostname_valid_http(self):
@@ -75,7 +75,7 @@ class TestHelperFunctions(TestCase):
         self.assertEqual(result, "admin")
 
 
-class TestCowrieExtractionStrategy(TestCase):
+class TestCowrieExtractionStrategy(ExtractionTestCase):
     """Test CowrieExtractionStrategy class."""
 
     def setUp(self):

--- a/tests/test_ntfy.py
+++ b/tests/test_ntfy.py
@@ -1,17 +1,17 @@
 from unittest.mock import MagicMock, patch
 
-from django.test import SimpleTestCase, override_settings
+from django.test import override_settings
 
 from greedybear.ntfy import send_ntfy_message
+from tests import CustomTestCase
 
 TEST_LOGGING = {
     "version": 1,
     "disable_existing_loggers": True,
 }
 
-
 @override_settings(LOGGING=TEST_LOGGING)
-class SendNtfyMessageTests(SimpleTestCase):
+class SendNtfyMessageTests(CustomTestCase):
     @override_settings(NTFY_URL="https://ntfy.sh/greedybear")
     @patch("greedybear.ntfy.requests.post")
     @patch("greedybear.ntfy.logger")

--- a/tests/test_rf_config.py
+++ b/tests/test_rf_config.py
@@ -1,12 +1,11 @@
 import json
 
-from django.test import SimpleTestCase
-
 from greedybear.cronjobs.scoring.random_forest import RFClassifier, RFRegressor
 from greedybear.settings import ML_CONFIG_FILE
+from tests import CustomTestCase
 
 
-class TestRFConfig(SimpleTestCase):
+class TestRFConfig(CustomTestCase):
     def setUp(self):
         with open(ML_CONFIG_FILE) as f:
             self.config = json.load(f)

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,26 +1,21 @@
 import random
 from itertools import product
 
-from django.test import TestCase
 from rest_framework.serializers import ValidationError
 
 from api.serializers import FeedsRequestSerializer, FeedsResponseSerializer
 from greedybear.consts import PAYLOAD_REQUEST, SCANNER
 from greedybear.models import IOC, GeneralHoneypot
+from tests import CustomTestCase
 
 
-class FeedsRequestSerializersTestCase(TestCase):
+class FeedsRequestSerializersTestCase(CustomTestCase):
     @classmethod
-    def setUpClass(cls):
-        GeneralHoneypot.objects.create(
-            name="adbhoney",
-            active=True,
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        # db clean
-        GeneralHoneypot.objects.all().delete()
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.adbhoney = GeneralHoneypot.objects.filter(name__iexact="adbhoney").first()
+        if not cls.adbhoney:
+            cls.adbhoney = GeneralHoneypot.objects.create(name="Adbhoney", active=True)
 
     def test_valid_fields(self):
         choices = {
@@ -92,18 +87,13 @@ class FeedsRequestSerializersTestCase(TestCase):
             self.assertIn("format", serializer.errors)
 
 
-class FeedsResponseSerializersTestCase(TestCase):
+class FeedsResponseSerializersTestCase(CustomTestCase):
     @classmethod
-    def setUpClass(cls):
-        GeneralHoneypot.objects.create(
-            name="adbhoney",
-            active=True,
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        # db clean
-        GeneralHoneypot.objects.all().delete()
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.adbhoney = GeneralHoneypot.objects.filter(name__iexact="adbhoney").first()
+        if not cls.adbhoney:
+            cls.adbhoney = GeneralHoneypot.objects.create(name="Adbhoney", active=True)
 
     def test_valid_fields(self):
         scanner_choices = [True, False]


### PR DESCRIPTION
# Description

Standardized all tests to inherit from [CustomTestCase](cci:2://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:16:0-185:46) or [ExtractionTestCase](cci:2://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:188:0-223:19) as defined in [tests/__init__.py](cci:7://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:0:0-0:0), addressing the inconsistent inheritance pattern across the test suite.

## Changes Made

- Changed `SimpleTestCase` to [CustomTestCase](cci:2://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:16:0-185:46) in [test_ntfy.py](cci:7://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/test_ntfy.py:0:0-0:0) and [test_rf_config.py](cci:7://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/test_rf_config.py:0:0-0:0)
- Changed [TestCase](cci:2://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:16:0-185:46) to [CustomTestCase](cci:2://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:16:0-185:46) in [test_serializers.py](cci:7://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/test_serializers.py:0:0-0:0) (also updated `setUpClass` → [setUpTestData](cci:1://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:17:4-177:127) with proper `super()` call)
- Changed `unittest.TestCase` to [ExtractionTestCase](cci:2://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:188:0-223:19) in [test_cowrie_extraction.py](cci:7://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/test_cowrie_extraction.py:0:0-0:0)
- Changed `unittest.TestCase` to [CustomTestCase](cci:2://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/__init__.py:16:0-185:46) in [test_monitor_logs.py](cci:7://file:///media/raviteja/New%20Volume/GSOC/Honeynet/GreedyBear/tests/greedybear/cronjobs/test_monitor_logs.py:0:0-0:0)

## Related issues

Closes #700

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [x] I have added documentation of the new features.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.