### PR TITLE
Add migration to remove hard-coded honeypots. Fixes #632

### DIFF
--- a/greedybear/migrations/0029_remove_hardcoded_honeypots.py
+++ b/greedybear/migrations/0029_remove_hardcoded_honeypots.py
@@ -46,6 +46,7 @@ def remove_hardcoded_honeypots(apps, schema_editor):
 class Migration(migrations.Migration):
     dependencies = [
         ("greedybear", "0027_disable_unwanted_honeypots"),
+        ("greedybear", "0028_generalhoneypot_unique_generalhoneypot_name_ci"),
     ]
 
     operations = [


### PR DESCRIPTION
# Description

This PR adds a new migration to remove the 15 hard-coded honeypots that were originally created in migration 0008. 

The migration safely deletes these honeypots only if they have no associated IOC data. I followed the same pattern used in migration 0014 for consistency.

## Related issues

Fixes #632

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [x] I have added documentation of the new features.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.