### PR TITLE
Make Celery wait for RabbitMQ via healthcheck (fix #720)

### DIFF
--- a/docker/default.yml
+++ b/docker/default.yml
@@ -52,6 +52,12 @@ services:
       driver: none
     depends_on:
       - postgres
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "check_running"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 10s
 
   celery_beat:
     image: intelowlproject/greedybear:prod
@@ -63,9 +69,12 @@ services:
     env_file:
       - env_file
     depends_on:
-      - rabbitmq
-      - postgres
-      - uwsgi
+      rabbitmq:
+        condition: service_healthy
+      postgres:
+        condition: service_started
+      uwsgi:
+        condition: service_started
     <<: *no-healthcheck
 
   celery_worker_default:
@@ -80,11 +89,13 @@ services:
     env_file:
       - env_file
     depends_on:
-      - rabbitmq
-      - postgres
-      - uwsgi
+      rabbitmq:
+        condition: service_healthy
+      postgres:
+        condition: service_started
+      uwsgi:
+        condition: service_started
     <<: *no-healthcheck
-
 
 volumes:
   postgres_data:


### PR DESCRIPTION
# Description

This PR updates the Docker Compose configuration so that RabbitMQ is started first and Celery services only start once RabbitMQ is actually healthy.  
Specifically, a **healthcheck** is added to the `rabbitmq` service and the `depends_on` configuration for `celery_beat` and `celery_worker_default` is updated to use `condition: service_healthy` for RabbitMQ (while keeping Postgres and uwsgi as `service_started`).  
After these changes, repeated `docker compose -f docker/default.yml down && docker compose -f docker/default.yml up -d` cycles no longer produce floods of transient “Cannot connect to RabbitMQ” / “Connection refused” messages in the Celery logs, while genuine Celery/RabbitMQ issues still surface as expected. [page:1][page:51]

## Related issues

- Fixes #720

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
  - [ ] I have a provided a screenshot of the result in the PR.
  - [ ] I have created new frontend tests for the new component or updated existing ones.
