### PR TITLE
feat: Disable additional honeypots (Closes #738)

### DIFF
--- a/greedybear/migrations/0033_disable_additional_honeypots.py
+++ b/greedybear/migrations/0033_disable_additional_honeypots.py
@@ -1,0 +1,35 @@
+from django.db import migrations
+
+
+def disable_additional_honeypots(apps, schema_editor):
+    """
+    Disable additional honeypots: Fatt, P0f, ssh-dss, ssh-ed25519
+    """
+    GeneralHoneypot = apps.get_model("greedybear", "GeneralHoneypot")
+
+    unwanted = [
+        "Fatt",
+        "P0f",
+        "ssh-dss",
+        "ssh-ed25519",
+    ]
+
+    for name in unwanted:
+        GeneralHoneypot.objects.get_or_create(
+            name=name,
+            defaults={"active": False},
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("greedybear", "0032_torexitnode"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            disable_additional_honeypots,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
# Description

This PR disables four additional honeypots that should not be used for data extraction.

Following up on #631, this migration ensures the following honeypots are marked as `active=False`:
- **Fatt**
- **P0f**
- **ssh-dss**
- **ssh-ed25519**

## Related issues
Closes #738

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about how to Contribute to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [x] Linter (`Ruff`) gave 0 errors.
- [ ] I have added tests for the feature/bug I solved.