### PR TITLE
fix: Remove redundant honeypots field from feeds API response (Fixes …

### DIFF
--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -275,9 +275,11 @@ def feeds_response(iocs, feed_params, valid_feed_types, dict_only=False, verbose
 
                 # Remove verbose-only fields from response when not in verbose mode
                 if not verbose:
-                    # Remove honeypots and destination_ports arrays from response
-                    data_.pop("honeypots", None)
+                    # Remove destination_ports array from response
                     data_.pop("destination_ports", None)
+
+                # Always remove honeypots field as it's redundant with feed_type
+                data_.pop("honeypots", None)
 
                 # Skip validation - data_ is constructed internally and matches the API contract
                 json_list.append(data_)


### PR DESCRIPTION
# Description

Cleaned up the feeds API by removing the redundant [honeypots](cci:1://file:///Users/sumitdas/Desktop/GreedyBearAI/GreedyBear/greedybear/migrations/0027_disable_unwanted_honeypots.py:3:0-19:9) field.

Both [honeypots](cci:1://file:///Users/sumitdas/Desktop/GreedyBearAI/GreedyBear/greedybear/migrations/0027_disable_unwanted_honeypots.py:3:0-19:9) and [feed_type](cci:1://file:///Users/sumitdas/Desktop/GreedyBearAI/GreedyBear/tests/test_views.py:486:4-500:57) were returning the same data (just with different casing), so I removed [honeypots](cci:1://file:///Users/sumitdas/Desktop/GreedyBearAI/GreedyBear/greedybear/migrations/0027_disable_unwanted_honeypots.py:3:0-19:9) and kept [feed_type](cci:1://file:///Users/sumitdas/Desktop/GreedyBearAI/GreedyBear/tests/test_views.py:486:4-500:57).

**How it works now:**
- Still fetch honeypots from the DB to calculate feed_type
- Just don't include it in the response anymore
- Users only see feed_type (which has all the info they need)

**About ML models:** They pull data directly from the database, not from this API, so they're not affected.

## Related issues
Fixes #744

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about how to Contribute to this project.
- [x] The pull request is for the branch `develop`.
- [x] Linter (`Ruff`) gave 0 errors.