### PR TITLE
Tooltip to show feed scores on frontend closes #461

### DIFF
--- a/frontend/src/components/feeds/tableColumns.jsx
+++ b/frontend/src/components/feeds/tableColumns.jsx
@@ -1,6 +1,20 @@
-import { BooleanIcon } from "@certego/certego-ui";
+import { UncontrolledPopover, PopoverBody } from "reactstrap";
+import { FiInfo } from "react-icons/fi";
+import { BooleanIcon, IconButton } from "@certego/certego-ui";
 
-// costants
+
+const formatInteger = (value) => {
+  if (value === null || value === undefined || Number.isNaN(value)) return "-";
+  return Number(value).toLocaleString();
+};
+
+// required for recurrence value
+const formatPercent = (value) => {
+  if (value === null || value === undefined || Number.isNaN(value)) return "-";
+  return `${(Number(value) * 100).toFixed(1)}%`;
+};
+
+// constants
 const feedsTableColumns = [
   {
     Header: "Last Seen",
@@ -35,20 +49,69 @@ const feedsTableColumns = [
       ),
   },
   {
-    Header: "Scanner",
-    accessor: "scanner",
-    Cell: ({ value }) => <BooleanIcon truthy={value} withColors />,
+    Header: "Attack Count",
+    accessor: "attack_count",
     maxWidth: 60,
   },
   {
-    Header: "Payload Request",
-    accessor: "payload_request",
-    Cell: ({ value }) => <BooleanIcon truthy={value} withColors />,
-    maxWidth: 70,
-  },
-  {
-    Header: "Attack Count",
-    accessor: "attack_count",
+    Header: "Details",
+    accessor: "details",
+    Cell: ({ row }) => {
+      const {
+        scanner,
+        payload_request,
+        recurrence_probability,
+        expected_interactions,
+        interaction_count,
+        destination_port_count,
+        login_attempts,
+        asn,
+        ip_reputation,
+      } = row.original;
+      const popoverId = `feeds-details-${row.id}`;
+      return (
+        <div className="d-flex justify-content-center">
+          <IconButton
+            id={popoverId}
+            color="light"
+            outline
+            size="xs"
+            Icon={FiInfo}
+          />
+          <UncontrolledPopover
+            trigger="hover"
+            target={popoverId}
+            placement="left"
+            className="feeds-details-popover"
+          >
+            <PopoverBody className="small">
+              <div className="text-muted">Scores</div>
+              <div>Recurrence: {formatPercent(recurrence_probability)}</div>
+              <div>Expected: {formatInteger(Math.round(expected_interactions))}</div>
+              <hr className="my-2" />
+              <div className="text-muted">Activity</div>
+              <div>Interactions: {formatInteger(interaction_count)}</div>
+              <div>Ports: {formatInteger(destination_port_count)}</div>
+              <div>Logins: {formatInteger(login_attempts)}</div>
+              <hr className="my-2" />
+              <div className="text-muted">Enrichment</div>
+              <div>ASN: {formatInteger(asn)}</div>
+              <div>Reputation: {ip_reputation || "-"}</div>
+              <hr className="my-2" />
+              <div className="text-muted">Flags</div>
+              <div className="d-flex align-items-center">
+                <span className="me-2">Scanner</span>
+                <BooleanIcon truthy={scanner} withColors />
+              </div>
+              <div className="d-flex align-items-center">
+                <span className="me-2">Payload</span>
+                <BooleanIcon truthy={payload_request} withColors />
+              </div>
+            </PopoverBody>
+          </UncontrolledPopover>
+        </div>
+      );
+    },
     maxWidth: 60,
   },
 ];

--- a/frontend/src/styles/App.scss
+++ b/frontend/src/styles/App.scss
@@ -152,3 +152,24 @@ section.fixed-bottom {
 .recharts-tooltip-wrapper {
   z-index: 99999 !important;
 }
+
+.feeds-details-popover {
+  .popover {
+    background-color: $darker;
+  }
+  
+  .popover-body {
+    color: $light;
+  }
+
+  .popover-header {
+    background-color: $darker;
+    color: $light;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .popover-arrow::before,
+  .popover-arrow::after {
+    border-color: $darker;
+  }
+}


### PR DESCRIPTION
# Description
Display scores in feed on frontend.
Moved Scanner and Payload columns into Details column also.

## Related issues
#461

## Type of change
- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [x] I have added documentation of the new features.
- [ ] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [x] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [x] If the GUI has been modified:
    - [x] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.

<img width="2345" height="1006" alt="2026-02-04T18:42:32,942937823+05:30" src="https://github.com/user-attachments/assets/7ad26397-d8a3-42fc-8096-8124130c548b" />