### PR TITLE
Fix feed_type sorting at DB level before pagination. Closes #421

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -71,6 +71,9 @@ def feed_type_validation(feed_type: str, valid_feed_types: frozenset) -> str:
     return feed_type
 
 
+ANNOTATION_ORDERING_FIELDS = frozenset({"feed_type", "honeypots"})
+
+
 @cache
 def ordering_validation(ordering: str) -> str:
     """Validates that given ordering corresponds to a field in the IOC model.
@@ -86,8 +89,9 @@ def ordering_validation(ordering: str) -> str:
     """
     if not ordering:
         raise serializers.ValidationError("Invalid ordering: <empty string>")
-    # remove minus sign if present
     field_name = ordering[1:] if ordering.startswith("-") else ordering
+    if field_name in ANNOTATION_ORDERING_FIELDS:
+        return ordering
     try:
         IOC._meta.get_field(field_name)
     except FieldDoesNotExist as exc:

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -76,10 +76,11 @@ class FeedRequestParams:
         self.exclude_reputation = query_params["exclude_reputation"].split(";") if "exclude_reputation" in query_params else []
         self.feed_size = query_params.get("feed_size", "5000")
         self.ordering = query_params.get("ordering", "-last_seen").lower().replace("value", "name")
+        if "feed_type" in self.ordering:
+            self.ordering = self.ordering.replace("feed_type", "honeypots")
         self.verbose = query_params.get("verbose", "false").lower()
         self.paginate = query_params.get("paginate", "false").lower()
         self.format = query_params.get("format_", "json").lower()
-        self.feed_type_sorting = None
 
     def apply_default_filters(self, query_params):
         if not query_params:
@@ -94,15 +95,9 @@ class FeedRequestParams:
             case "recent":
                 self.max_age = "3"
                 self.min_days_seen = "1"
-                if "feed_type" in self.ordering:
-                    self.feed_type_sorting = self.ordering
-                    self.ordering = "-last_seen"
             case "persistent":
                 self.max_age = "14"
                 self.min_days_seen = "10"
-                if "feed_type" in self.ordering:
-                    self.feed_type_sorting = self.ordering
-                    self.ordering = "-attack_count"
             case "likely_to_recur":
                 self.max_age = "30"
                 self.min_days_seen = "1"
@@ -287,15 +282,6 @@ def feeds_response(iocs, feed_params, valid_feed_types, dict_only=False, verbose
 
                 # Skip validation - data_ is constructed internally and matches the API contract
                 json_list.append(data_)
-
-            # check if sorting the results by feed_type
-            if feed_params.feed_type_sorting is not None:
-                logger.info("Return feeds sorted by feed_type field")
-                json_list = sorted(
-                    json_list,
-                    key=lambda k: k["feed_type"],
-                    reverse=feed_params.feed_type_sorting == "-feed_type",
-                )
 
             logger.info(f"Number of feeds returned: {len(json_list)}")
             resp_data = {"iocs": json_list}

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -35,7 +35,7 @@ class FeedsRequestSerializersTestCase(CustomTestCase):
                 ["known attacker", "mass scanner"],
             ],
             "feed_size": [str(n) for n in [100, 200, 5000, 10_000_000]],
-            "ordering": [field.name for field in IOC._meta.get_fields()],
+            "ordering": [field.name for field in IOC._meta.get_fields()] + ["feed_type"],
             "verbose": ["true", "false"],
             "paginate": ["true", "false"],
             "format": ["txt", "json", "csv"],

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -196,6 +196,14 @@ class FeedsViewTestCase(CustomTestCase):
         # Should return only domains (1 in test data)
         self.assertEqual(response.json()["count"], 1)
 
+    def test_200_feeds_pagination_ordering_feed_type(self):
+        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&ordering=feed_type")
+        self.assertEqual(response.status_code, 200)
+
+    def test_200_feeds_pagination_ordering_feed_type_desc(self):
+        response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=all&age=recent&ordering=-feed_type")
+        self.assertEqual(response.status_code, 200)
+
     def test_400_feeds_pagination(self):
         response = self.client.get("/api/feeds/?page_size=10&page=1&feed_type=all&attack_type=test&age=recent")
         self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
# Description

When sorting by "Feed type" in the frontend, only the currently displayed page of rows was being sorted — not the entire result set. This happened because `feed_type` sorting was applied in Python *after* pagination had already sliced the queryset, so the sort only affected the current page's IOCs.

This PR fixes the issue by moving `feed_type` sorting to the database level. Since `feed_type` is not a concrete model field but a derived annotation (`honeypots`), the fix:

1. **Translates** `feed_type` ordering to `honeypots` ordering in `FeedRequestParams.__init__`, so the ORM applies it before pagination.
2. **Validates** `feed_type` (and `honeypots`) as legitimate ordering fields in `ordering_validation()` by introducing an `ANNOTATION_ORDERING_FIELDS` set that bypasses the `IOC._meta.get_field()` check.
3. **Removes** the old Python-level post-pagination sorting logic (`feed_type_sorting` attribute and the `sorted()` call in `feeds_response`).

## Related issues

Closes #421

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).