### PR TITLE
Fix changing the prioritization not resetting the ordering indicator. Closes #782

### DIFF
--- a/frontend/src/components/feeds/Feeds.jsx
+++ b/frontend/src/components/feeds/Feeds.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Container, Button, Col, Label, FormGroup, Row } from "reactstrap";
 import { VscJson } from "react-icons/vsc";
 import { TbLicense } from "react-icons/tb";
+import { useNavigate, useLocation } from "react-router-dom";
 import { FEEDS_BASE_URI, GENERAL_HONEYPOT_URI } from "../../constants/api";
 import {
   ContentSection,
@@ -13,7 +14,7 @@ import { Form, Formik } from "formik";
 import { feedsTableColumns } from "./tableColumns";
 import { FEEDS_LICENSE } from "../../constants";
 
-// costants
+// constants
 const feedTypeChoices = [{ label: "All", value: "all" }];
 
 const attackTypeChoices = [
@@ -42,10 +43,6 @@ const initialValues = {
   prioritize: "recent",
 };
 
-const initialState = {
-  pageIndex: 0,
-};
-
 const toPassTableProps = {
   columns: feedsTableColumns,
   tableEmptyNode: (
@@ -56,16 +53,67 @@ const toPassTableProps = {
   ),
 };
 
+// prioritizations where backend overrides "ordering" query param.
+const OVERRIDING_PRIORITIZATIONS = ["likely_to_recur", "most_expected_hits"];
+
 let honeypotFeedsType = [];
+
+// extracted child component so useDataTable hooks are owned here.
+// changing the `key` on this component forces a full unmount/remount.
+function FeedsTable({ tableParams, onDataLoad, onSortChange }) {
+  const location = useLocation();
+
+  const [feedsData, tableNode] = useDataTable(
+    {
+      url: FEEDS_BASE_URI,
+      params: tableParams,
+      initialParams: {
+        page: "1",
+      },
+    },
+    toPassTableProps,
+    (data) => data.results.iocs
+  );
+
+  // Notify parent of data changes so it can display the count
+  React.useEffect(() => {
+    if (onDataLoad) {
+      onDataLoad(feedsData);
+    }
+  }, [feedsData, onDataLoad]);
+
+  // if the current prioritization mode overrides ordering on the backend
+  // notify the parent so it can reset prioritization to "recent".
+  React.useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    if (
+      params.has("ordering") &&
+      OVERRIDING_PRIORITIZATIONS.includes(tableParams.prioritize) &&
+      onSortChange
+    ) {
+      onSortChange();
+    }
+  }, [location.search, tableParams.prioritize, onSortChange]);
+
+  return tableNode;
+}
 
 export default function Feeds() {
   console.debug("Feeds rendered!");
 
   console.debug("Feeds-initialValues", initialValues);
 
+  const navigate = useNavigate();
+
   const [url, setUrl] = React.useState(
     `${FEEDS_BASE_URI}/${initialValues.feeds_type}/${initialValues.attack_type}/${initialValues.prioritize}.json`
   );
+
+  // Counter used to force remount FeedsTable
+  const [tableKey, setTableKey] = React.useState(0);
+
+  // feedsData is lifted from FeedsTable so we can show the count in the header
+  const [feedsData, setFeedsData] = React.useState(null);
 
   // API to extract general honeypot
   const [honeypots, Loader] = useAxiosComponentLoader({
@@ -84,22 +132,14 @@ export default function Feeds() {
       });
   });
 
-  const [feedsData, tableNode, , tableStateReducer] = useDataTable(
-    {
-      url: FEEDS_BASE_URI,
-      params: {
-        feed_type: initialValues.feeds_type,
-        attack_type: initialValues.attack_type,
-        ioc_type: initialValues.ioc_type,
-        prioritize: initialValues.prioritize,
-      },
-      initialParams: {
-        page: "1",
-      },
-    },
-    toPassTableProps,
-    (data) => data.results.iocs
-  );
+  // reset the prioritize dropdown to "recent"
+  const handleSortChange = React.useCallback(() => {
+    initialValues.prioritize = "recent";
+    setUrl(
+      `${FEEDS_BASE_URI}/${initialValues.feeds_type}/${initialValues.attack_type}/recent.json?ioc_type=${initialValues.ioc_type}`
+    );
+    setTableKey((prev) => prev + 1);
+  }, [setUrl]);
 
   // callbacks
   const onSubmit = React.useCallback(
@@ -113,16 +153,16 @@ export default function Feeds() {
         initialValues.ioc_type = values.ioc_type;
         initialValues.prioritize = values.prioritize;
 
-        const resetPage = {
-          type: "gotoPage",
-          pageIndex: 0,
-        };
-        tableStateReducer(initialState, resetPage);
+        // Clear any ordering / page query params.
+        navigate({ search: "" }, { replace: true });
+
+        // force remount FeedsTable
+        setTableKey((prev) => prev + 1);
       } catch (e) {
         console.debug(e);
       }
     },
-    [setUrl, tableStateReducer]
+    [setUrl, navigate]
   );
 
   return (
@@ -250,7 +290,17 @@ export default function Feeds() {
           </Col>
         </Row>
         {/*Table*/}
-        {tableNode}
+        <FeedsTable
+          key={tableKey}
+          tableParams={{
+            feed_type: initialValues.feeds_type,
+            attack_type: initialValues.attack_type,
+            ioc_type: initialValues.ioc_type,
+            prioritize: initialValues.prioritize,
+          }}
+          onDataLoad={setFeedsData}
+          onSortChange={handleSortChange}
+        />
       </ContentSection>
     </Container>
   );


### PR DESCRIPTION
# Description
Fixed changing the prioritization on the Feeds page does not reset the ordering indicator.
Refer to #782 for detail about the solution.

## Related issues
#782 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.