### PR TITLE
Fix homepage logo on smaller screens

### DIFF
--- a/frontend/src/components/home/Home.scss
+++ b/frontend/src/components/home/Home.scss
@@ -15,10 +15,9 @@ html {
   left: -50px;
   opacity: 1;
   background-position: center;
-  background-size: 15%;
+  background-size: clamp(200px, 15vw, 300px) auto;
   background-repeat: no-repeat;
   min-height: 100% !important;
-  background-size: clamp(200px, 15vw, 300px) auto;
 }
 
 #home__versionText {


### PR DESCRIPTION
# Description
Logo looked too small on smaller screen.
use CSS `clamp()` to scale with proper bounds

## Related issues
Closes #855 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

## Screenshot
<img width="300" alt="image" src="https://github.com/user-attachments/assets/dc06afaa-7dc7-460f-a5b3-47254a9fb81e" />


# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [x] If the GUI has been modified:
    - [x] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
  
