### PR TITLE
Fix session list sorting on frontend. Closes #866

### DIFF
--- a/frontend/src/components/me/sessions/SessionList.jsx
+++ b/frontend/src/components/me/sessions/SessionList.jsx
@@ -21,7 +21,13 @@ export default function SessionsList() {
       headers: { "Content-Type": "application/json" },
     },
     (respData) =>
-      respData.sort((a, b) => !a.is_current || a.created - b.created),
+      respData.sort((a, b) => {
+        // Sort current session first
+        if (a.is_current && !b.is_current) return -1;
+        if (!a.is_current && b.is_current) return 1;
+        // otherwise sort by most recent first
+        return b.created - a.created;
+      }),
   );
 
   // callbacks


### PR DESCRIPTION
# Description
Fix the incorrect session sorting logic on frontend.
Place Current session first, and sort remaining by most recent first.

## Related issues
#866

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [ ] I have added documentation of the new features.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/docs/blob/main/docs/GreedyBear/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
