### PR TITLE
fix(api): replace regex IP validation with ipaddress stdlib in EnrichmentSerializer

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,3 +1,4 @@
+import ipaddress
 import logging
 import re
 from functools import cache
@@ -5,7 +6,7 @@ from functools import cache
 from django.core.exceptions import FieldDoesNotExist
 from rest_framework import serializers
 
-from greedybear.consts import REGEX_DOMAIN, REGEX_IP
+from greedybear.consts import REGEX_DOMAIN
 from greedybear.models import IOC, GeneralHoneypot
 
 logger = logging.getLogger(__name__)
@@ -36,13 +37,22 @@ class EnrichmentSerializer(serializers.Serializer):
 
     def validate(self, data):
         """
-        Check a given observable against regex expression
+        Validate that the query is a valid IP address (IPv4/IPv6) or domain.
         """
-        observable = data["query"]
-        if re.match(r"^[\d\.]+$", observable) and not re.match(REGEX_IP, observable):
-            raise serializers.ValidationError("Observable is not a valid IP")
-        if not re.match(REGEX_IP, observable) and not re.match(REGEX_DOMAIN, observable):
-            raise serializers.ValidationError("Observable is not a valid IP or domain")
+        observable = data["query"].strip()
+
+        try:
+            ipaddress.ip_address(observable)
+            is_ip = True
+        except ValueError:
+            is_ip = False
+
+        # A valid domain must match the domain regex AND contain at least one
+        is_domain = bool(re.match(REGEX_DOMAIN, observable)) and any(c.isalpha() for c in observable)
+
+        if not is_ip and not is_domain:
+            raise serializers.ValidationError("Observable is not a valid IP address or domain")
+
         try:
             required_object = IOC.objects.get(name=observable)
             data["found"] = True

--- a/tests/api/views/test_enrichment_view.py
+++ b/tests/api/views/test_enrichment_view.py
@@ -59,3 +59,24 @@ class EnrichmentViewTestCase(CustomTestCase):
         self.client.logout()
         response = self.client.get("/api/enrichment?query=140.246.171.141")
         self.assertEqual(response.status_code, 401)
+
+    def test_invalid_ip_octet_over_255(self):
+        """IPs with octets > 255 should be rejected (fixes #881)"""
+        response = self.client.get("/api/enrichment?query=999.999.999.999")
+        self.assertEqual(response.status_code, 400)
+
+    def test_invalid_ip_octet_256(self):
+        """IP with octet = 256 should be rejected"""
+        response = self.client.get("/api/enrichment?query=256.1.1.1")
+        self.assertEqual(response.status_code, 400)
+
+    def test_valid_ipv6_address(self):
+        """Valid IPv6 addresses should be accepted"""
+        response = self.client.get("/api/enrichment?query=2001:db8::1")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["found"], False)
+
+    def test_query_with_whitespace(self):
+        """Query with leading/trailing whitespace should be handled"""
+        response = self.client.get("/api/enrichment?query=  192.168.0.1  ")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Fixes #881

## Problem
`EnrichmentSerializer.validate()` used `REGEX_IP` which only checked digit count per octet (`\d{1,3}`), not the valid 0-255 range. This caused invalid IPs to be accepted:
```
999.999.999.999 -> accepted (should be rejected)
256.1.1.1       -> accepted (should be rejected)
```

Additionally, valid IPv6 addresses like `2001:db8::1` were incorrectly rejected.

## Changes
- Replaced `REGEX_IP` regex with `ipaddress.ip_address()` from Python stdlib
- Added `.strip()` for whitespace handling
- Removed unused `REGEX_IP` import from serializers
- IPv6 addresses now accepted correctly

## Tests Added
- `test_invalid_ip_octet_over_255` - verifies 999.999.999.999 is rejected
- `test_invalid_ip_octet_256` - verifies 256.1.1.1 is rejected
- `test_valid_ipv6_address` - verifies 2001:db8::1 is accepted
- `test_query_with_whitespace` - verifies whitespace is stripped before validation

## Test Results
```
Ran 468 tests in 17.823s

OK
```

## Implementation Note
@regulartim suggested using the existing `is_ip_address()` from `api/views/utils.py`. However, importing it directly caused a circular import since `api/views/utils.py` imports from `api/serializers.py`. Used `ipaddress.ip_address()` directly instead, which is the same underlying implementation. Happy to refactor if there is a preferred way to break the circular dependency.
