### PR TITLE
Fix: clear user data and isSuperuser on logout

### DIFF
--- a/frontend/src/stores/useAuthStore.jsx
+++ b/frontend/src/stores/useAuthStore.jsx
@@ -75,7 +75,7 @@ const useAuthStore = create((set, get) => ({
       const onLogoutCb = () => {
         set({
           isAuthenticated: AUTHENTICATION_STATUSES.FALSE,
-          user: { full_name: "", first_name: "", last_name: "", email: "" }, 
+          user: { full_name: "", first_name: "", last_name: "", email: "" },
           isSuperuser: false,
         });
         addToast("Logged out!", null, "info");

--- a/frontend/tests/components/auth/Logout.test.jsx
+++ b/frontend/tests/components/auth/Logout.test.jsx
@@ -33,22 +33,29 @@ describe("Logout component", () => {
   });
 
   test("User data and isSuperuser are cleared after logout", async () => {
-  // set store with correct user shape matching useAuthStore initial values
-  useAuthStore.setState({
-    isAuthenticated: AUTHENTICATION_STATUSES.TRUE,
-    user: { full_name: "Test User", first_name: "Test", last_name: "User", email: "test@test.com" },
-    isSuperuser: true,
-  });
+    // set store with correct user shape matching useAuthStore initial values
+    useAuthStore.setState({
+      isAuthenticated: AUTHENTICATION_STATUSES.TRUE,
+      user: {
+        full_name: "Test User",
+        first_name: "Test",
+        last_name: "User",
+        email: "test@test.com",
+      },
+      isSuperuser: true,
+    });
 
-  await useAuthStore.getState().service.logoutUser();
+    await useAuthStore.getState().service.logoutUser();
 
-  expect(useAuthStore.getState().user).toEqual({
-    full_name: "",
-    first_name: "",
-    last_name: "",
-    email: "",
+    expect(useAuthStore.getState().user).toEqual({
+      full_name: "",
+      first_name: "",
+      last_name: "",
+      email: "",
+    });
+    expect(useAuthStore.getState().isSuperuser).toBe(false);
+    expect(useAuthStore.getState().isAuthenticated).toBe(
+      AUTHENTICATION_STATUSES.FALSE,
+    );
   });
-  expect(useAuthStore.getState().isSuperuser).toBe(false);
-  expect(useAuthStore.getState().isAuthenticated).toBe(AUTHENTICATION_STATUSES.FALSE);
-});
 });


### PR DESCRIPTION
# Description
In` useAuthStore.js`, the` onLogoutCb` function was not resetting the user object and `isSuperuser` flag on logout. This meant stale data from the previous session persisted in the store, and a second user logging in on the same browser session could briefly inherit the previous user's data until `fetchUserAccess` resolved.
### Related issues

 ---

### Type of change
- [X] Bug fix (non-breaking change which fixes an issue).

 ---

### Formalities
- [X] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [X] I chose an appropriate title for the pull request in the form: `<Fix: clear user data and isSuperuser on logout.>. Closes #893`
- [X] My branch is based on `develop`.
- [X] The pull request is for the branch `develop`.

 ---
### Docs and tests
- [X] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [X] I have added tests for the feature/bug I solved.
- [X] All the tests gave 0 errors.
  
 ---

Closes #893 
