### PR TITLE
feat(api): Geo related field addition in the feed_response. Closes #524

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -188,6 +188,7 @@ class FeedsResponseSerializer(serializers.Serializer):
     login_attempts = serializers.IntegerField(min_value=0)
     recurrence_probability = serializers.FloatField(min_value=0, max_value=1)
     expected_interactions = serializers.FloatField(min_value=0)
+    attacker_country = serializers.CharField(allow_null=True, allow_blank=True, max_length=120)
 
     def validate_feed_type(self, feed_type):
         logger.debug(f"FeedsResponseSerializer - validation feed_type: '{feed_type}'")

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -2,7 +2,6 @@
 # See the file 'LICENSE' for copying permission.
 import csv
 import logging
-from collections import defaultdict
 from datetime import datetime, timedelta
 
 import feedparser
@@ -203,33 +202,6 @@ def ioc_as_dict(ioc, fields: set) -> dict:
     return {k: v for k, v in ioc.__dict__.items() if k in fields}
 
 
-def get_sensor_countries_map(ioc_ids):
-    """
-    Efficiently fetch unique sensor countries for a list of IOC IDs.
-
-    This implementation is fully batch-optimized, avoids N+1 queries.
-
-    Returns the countries in sorted order for deterministic results.
-    """
-    if not ioc_ids:
-        return {}
-
-    # Fetch all sensor-country links for these IOC IDs in ONE query
-    sensor_links = (
-        IOC.sensors.through.objects.filter(ioc_id__in=ioc_ids)
-        .select_related("sensor")
-        .values_list("ioc_id", "sensor__country")
-        .exclude(sensor__country__isnull=True)
-    )
-
-    countries_map = defaultdict(set)
-    for ioc_id, country in sensor_links.iterator(chunk_size=1000):
-        countries_map[ioc_id].add(country)
-
-    # Sort for deterministic order
-    return {ioc_id: sorted(countries) for ioc_id, countries in countries_map.items()}
-
-
 def feeds_response(iocs, feed_params, valid_feed_types, dict_only=False, verbose=False):
     """
     Format the IOC data into the requested format (e.g., JSON, CSV, TXT).
@@ -266,7 +238,6 @@ def feeds_response(iocs, feed_params, valid_feed_types, dict_only=False, verbose
 
             # Base fields always returned
             base_fields = {
-                "id",
                 "value",
                 "first_seen",
                 "last_seen",
@@ -293,23 +264,16 @@ def feeds_response(iocs, feed_params, valid_feed_types, dict_only=False, verbose
             # Fetch fields from database (always include honeypots and destination_ports)
             required_fields = base_fields | verbose_only_fields if verbose else base_fields
 
-            # Convert to list to prevent generator consumption
-            iocs_data = [ioc_as_dict(ioc, required_fields) for ioc in iocs] if isinstance(iocs, list) else list(iocs.values(*required_fields))
-
-            # Batch fetch sensor countries
-            current_ioc_ids = [ioc_dict["id"] for ioc_dict in iocs_data]
-            sensor_countries_map = get_sensor_countries_map(current_ioc_ids)
-
-            # Build final feed data
-            for ioc in iocs_data:
-                feed_type = [hp.lower() for hp in ioc.get("honeypots", []) if hp]
+            # Collect values; `honeypots` will contain the list of associated honeypot names
+            iocs = (ioc_as_dict(ioc, required_fields) for ioc in iocs) if isinstance(iocs, list) else iocs.values(*required_fields)
+            for ioc in iocs:
+                ioc_feed_type = [hp.lower() for hp in ioc.get("honeypots", []) if hp]
 
                 data_ = ioc | {
                     "first_seen": ioc["first_seen"].strftime("%Y-%m-%d"),
                     "last_seen": ioc["last_seen"].strftime("%Y-%m-%d"),
-                    "feed_type": feed_type,
+                    "feed_type": ioc_feed_type,
                     "destination_port_count": len(ioc.get("destination_ports", [])),
-                    "sensor_countries": sensor_countries_map.get(ioc["id"], []),
                 }
 
                 # Remove verbose-only fields from response when not in verbose mode

--- a/tests/api/views/test_feeds_advanced_view.py
+++ b/tests/api/views/test_feeds_advanced_view.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from rest_framework.test import APIClient
 
-from greedybear.models import Sensor
 from tests import CustomTestCase
 
 
@@ -80,29 +79,19 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         response = self.client.get("/api/feeds/advanced/?paginate=true&page_size=10&page=1&attack_type=test")
         self.assertEqual(response.status_code, 400)
 
-    def test_200_feed_contains_attacker_and_sensor_countries(self):
+    def test_200_feed_contains_attacker_country(self):
         """
-        Ensures that the response includes the new fields:
-        - attacker_country (from IOC)
-        - sensor_countries (from related sensors)
+        Ensures that the response includes the attacker_country field.
         """
 
-        # Create sensors explicitly for THIS test
-        sensor1 = Sensor.objects.create(address="10.0.0.1", country="Nepal")
-        sensor2 = Sensor.objects.create(address="10.0.0.2", country="Germany")
-
-        # Attach sensors to IOC
-        self.ioc.sensors.add(sensor1, sensor2)
-        self.ioc.attacker_country = "Bhutan"
+        # Setting attacker country for this IOC
+        self.ioc.attacker_country = "Nepal"
         self.ioc.save()
 
         response = self.client.get("/api/feeds/advanced/")
-        self.assertEqual(response.status_code, 200)
 
         iocs = response.json()["iocs"]
         target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+
         self.assertIsNotNone(target_ioc)
-
-        self.assertEqual(target_ioc["attacker_country"], "Bhutan")
-
-        self.assertEqual(target_ioc["sensor_countries"], ["Germany", "Nepal"])
+        self.assertEqual(target_ioc["attacker_country"], "Nepal")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -120,6 +120,7 @@ class FeedsResponseSerializersTestCase(CustomTestCase):
                 "login_attempts": "0",
                 "recurrence_probability": "0.1",
                 "expected_interactions": "11.1",
+                "attacker_country": "Nepal",
             }
             serializer = FeedsResponseSerializer(
                 data=data_,


### PR DESCRIPTION
# Description

Initially, I tried a simpler approach: adding an ArrayAgg annotation for sensor_countries in get_queryset and including it in a feed_response inside the base_fields. This was straightforward and clean  just two lines of change.

Issue with initial approach:

- Sensor_countries comes from a ManyToMany relation (IOC.sensors → Sensor.country). Annotating it in get_queryset (ArrayAgg) works only for that specific feed view.Any other place using the same queryset (scoring, cronjobs,  tests) doesn’t have that annotation. Also When feeds_response calls .values(*required_fields) with "sensor_countries" in base_fields, Django tries to look it up as a real model field, which fails causing FieldError.

Current Approach:

 - Removed sensor_countries from base_fields to prevent errors in non-feed code.

- Implemented get_sensor_countries_map to fetch sensor countries in batch, avoiding N+1 queries.

 - The feed response now includes sorted sensor_countries per IOC, along with attacker_country and other base fields.



### Related issues

closes: #524
related PR : #880

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
