### PR TITLE
fix: remove redundant loading state in EnrichmentLookup

### DIFF
--- a/frontend/src/components/dashboard/EnrichmentLookup.jsx
+++ b/frontend/src/components/dashboard/EnrichmentLookup.jsx
@@ -25,7 +25,6 @@ const initialValues = {
 
 export default function EnrichmentLookup() {
   const [result, setResult] = React.useState(null);
-  const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
 
   // auth store
@@ -54,8 +53,6 @@ export default function EnrichmentLookup() {
         return;
       }
 
-      setLoading(true);
-
       try {
         const resp = await axios.get(ENRICHMENT_URI, {
           params: { query: values.query.trim() },
@@ -78,7 +75,6 @@ export default function EnrichmentLookup() {
         setError(errorMsg);
         addToast("Error", errorMsg, "danger");
       } finally {
-        setLoading(false);
         setSubmitting(false);
       }
     },
@@ -121,7 +117,7 @@ export default function EnrichmentLookup() {
                 >
                   <MdSearch />
                   &nbsp;
-                  {loading ? "Searching..." : "Search"}
+                  {formik.isSubmitting ? "Searching..." : "Search"}
                 </Button>
               </Col>
             </FormGroup>


### PR DESCRIPTION
## Description
Fixes #901

This PR removes the redundant `loading` state in the `EnrichmentLookup` component and simplifies the Submit button to solely rely on Formik's `isSubmitting` state, as detailed in the issue.

### Changes Made
* Removed `loading` state definition and its setters.
* Updated `{loading ? "Searching..." : "Search"}` to `{formik.isSubmitting ? "Searching..." : "Search"}`.

All frontend test cases pass successfully.

### Atomic Focus
I carefully isolated this diff to just the relevant bits mentioned in the issue, avoiding unrelated/adjacent style changes to ensure this is as noise-free as possible.