### PR TITLE
Remove redundant loading state in EnrichmentLookup. Closes #901

### DIFF
--- a/frontend/src/components/dashboard/EnrichmentLookup.jsx
+++ b/frontend/src/components/dashboard/EnrichmentLookup.jsx
@@ -25,7 +25,6 @@ const initialValues = {
 
 export default function EnrichmentLookup() {
   const [result, setResult] = React.useState(null);
-  const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState(null);
 
   // auth store
@@ -54,8 +53,6 @@ export default function EnrichmentLookup() {
         return;
       }
 
-      setLoading(true);
-
       try {
         const resp = await axios.get(ENRICHMENT_URI, {
           params: { query: values.query.trim() },
@@ -78,7 +75,6 @@ export default function EnrichmentLookup() {
         setError(errorMsg);
         addToast("Error", errorMsg, "danger");
       } finally {
-        setLoading(false);
         setSubmitting(false);
       }
     },
@@ -121,7 +117,7 @@ export default function EnrichmentLookup() {
                 >
                   <MdSearch />
                   &nbsp;
-                  {loading ? "Searching..." : "Search"}
+                  {formik.isSubmitting ? "Searching..." : "Search"}
                 </Button>
               </Col>
             </FormGroup>


### PR DESCRIPTION
# Description

The `EnrichmentLookup` component maintained a redundant `loading` state (`const [loading, setLoading] = React.useState(false)`) alongside Formik's built-in `isSubmitting` state. Both tracked the same async lifecycle, causing unnecessary state duplication.

This PR removes the redundant `loading` state and updates the submit button text to rely solely on `formik.isSubmitting`.

### Related issues

- Closes #901

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). No doc changes needed.
- [x] Linter (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved. (Existing tests cover this — no new tests needed as no new logic is introduced.)
- [x] All the tests gave 0 errors.

### GUI changes

- [x] The button text source changes from local `loading` state to `formik.isSubmitting`. Behavior is identical — no visual difference.
- [x] Existing frontend tests pass without modification.