### PR TITLE
Propagate firehol_categories in _merge_iocs. Closes #922

### DIFF
--- a/greedybear/cronjobs/extraction/ioc_processor.py
+++ b/greedybear/cronjobs/extraction/ioc_processor.py
@@ -98,6 +98,7 @@ class IocProcessor:
         existing.destination_ports = sorted(set(existing.destination_ports + new.destination_ports))
         existing.ip_reputation = new.ip_reputation
         existing.asn = new.asn
+        existing.firehol_categories = list(new.firehol_categories)
         existing.login_attempts += new.login_attempts
 
         # we will always update attacker_country if incoming value exists

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -203,6 +203,7 @@ class ExtractionTestCase(CustomTestCase):
         last_seen=None,
         ip_reputation="",
         asn=1234,
+        firehol_categories=None,
     ):
         mock = Mock(spec=IOC)
         mock.name = name
@@ -218,6 +219,7 @@ class ExtractionTestCase(CustomTestCase):
         mock.last_seen = last_seen if last_seen is not None else datetime.now()
         mock.ip_reputation = ip_reputation
         mock.asn = asn
+        mock.firehol_categories = firehol_categories if firehol_categories is not None else []
         mock.number_of_days_seen = len(mock.days_seen)
         return mock
 

--- a/tests/test_ioc_processor.py
+++ b/tests/test_ioc_processor.py
@@ -253,6 +253,22 @@ class TestMergeIocs(ExtractionTestCase):
         self.assertEqual(result.related_urls, [])
         self.assertEqual(result.destination_ports, [])
 
+    def test_updates_firehol_categories(self):
+        existing = self._create_mock_ioc(firehol_categories=[])
+        new = self._create_mock_ioc(firehol_categories=["blocklist_de", "greensnow"])
+
+        result = self.processor._merge_iocs(existing, new)
+
+        self.assertEqual(sorted(result.firehol_categories), ["blocklist_de", "greensnow"])
+
+    def test_clears_stale_firehol_categories(self):
+        existing = self._create_mock_ioc(firehol_categories=["greensnow"])
+        new = self._create_mock_ioc(firehol_categories=[])
+
+        result = self.processor._merge_iocs(existing, new)
+
+        self.assertEqual(result.firehol_categories, [])
+
 
 class TestUpdateDaysSeen(ExtractionTestCase):
     def setUp(self):


### PR DESCRIPTION
# Description

`_merge_iocs()` updates 8 fields when re-extracting an existing IOC but never propagates `firehol_categories`. The field is frozen at IOC creation time, even though `iocs_from_hits()` computes fresh values via `get_firehol_categories()` on every extraction cycle.

This means new blocklist additions never reach existing IOCs, and removed entries are never cleared.

Fix: replace `firehol_categories` on merge (same semantics as `ip_reputation` and `asn` — current state, not historical accumulation).

### Related issues

Closes #922

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

- [ ] New feature (non-breaking change which adds functionality).

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.

- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`

- [x] My branch is based on `develop`.

- [x] The pull request is for the branch `develop`.

- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.

- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).

- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.

- [x] I have added tests for the feature/bug I solved.

- [x] All the tests gave 0 errors.

### GUI changes

N/A — no GUI changes.