### PR TITLE
rDNS-based noise filtering for known scanners. Closes #527

### DIFF
--- a/greedybear/consts.py
+++ b/greedybear/consts.py
@@ -33,6 +33,23 @@ REQUIRED_FIELDS = [
 ]
 
 
+# Mass scanner service domains for reverse DNS filtering.
+# If a PTR record ends with one of these, the IP is classified as a mass scanner.
+MASS_SCANNER_DOMAINS = frozenset(
+    {
+        "shodan.io",
+        "censys.io",
+        "onyphe.net",
+        "binaryedge.io",
+        "shadowserver.org",
+        "internet-census.org",
+        "stretchoid.com",
+        "internet-measurement.com",
+        "recyber.net",
+    }
+)
+
+
 # we used this const to implement news feature
 RSS_FEED_URL = "https://intelowlproject.github.io/feed.xml"
 CACHE_KEY_GREEDYBEAR_NEWS = "greedybear_news"

--- a/greedybear/cronjobs/extraction/ioc_processor.py
+++ b/greedybear/cronjobs/extraction/ioc_processor.py
@@ -99,7 +99,7 @@ class IocProcessor:
         existing.interaction_count += new.interaction_count
         existing.related_urls = sorted(set(existing.related_urls + new.related_urls))
         existing.destination_ports = sorted(set(existing.destination_ports + new.destination_ports))
-        existing.ip_reputation = new.ip_reputation
+        existing.ip_reputation = existing.ip_reputation or new.ip_reputation
         existing.asn = new.asn
         existing.firehol_categories = list(new.firehol_categories)
         existing.login_attempts += new.login_attempts

--- a/greedybear/cronjobs/repositories/tag.py
+++ b/greedybear/cronjobs/repositories/tag.py
@@ -50,6 +50,38 @@ class TagRepository:
             self.log.info(f"Created {len(tags_to_create)} tags from source '{source}'")
             return len(tags_to_create)
 
+    def add_tags(self, source: str, tag_entries: list[dict]) -> int:
+        """
+        Incrementally add tags for a source without removing existing ones.
+
+        Unlike replace_tags_for_source, this only creates new tags and
+        leaves previously stored tags intact. Suitable for sources that
+        build up results over many runs (e.g., reverse DNS lookups).
+
+        Args:
+            source: Source name (e.g., "rdns").
+            tag_entries: List of dicts with keys: ioc_id, key, value.
+
+        Returns:
+            Number of tags created.
+        """
+        if not tag_entries:
+            return 0
+
+        tags_to_create = [
+            Tag(
+                ioc_id=entry["ioc_id"],
+                key=entry["key"],
+                value=entry["value"],
+                source=source,
+            )
+            for entry in tag_entries
+        ]
+
+        Tag.objects.bulk_create(tags_to_create, batch_size=1000, ignore_conflicts=True)
+        self.log.info(f"Added {len(tags_to_create)} tags from source '{source}'")
+        return len(tags_to_create)
+
     def get_tags_by_ioc(self, ioc):
         """
         Get all tags for a specific IOC.

--- a/greedybear/cronjobs/reverse_dns.py
+++ b/greedybear/cronjobs/reverse_dns.py
@@ -1,0 +1,189 @@
+import socket
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from django.db.models import F
+
+from greedybear.consts import MASS_SCANNER_DOMAINS
+from greedybear.cronjobs.base import Cronjob
+from greedybear.cronjobs.repositories import IocRepository
+from greedybear.cronjobs.repositories.tag import TagRepository
+from greedybear.models import IOC, IocType
+
+# Number of concurrent DNS lookups.
+THREAD_POOL_SIZE = 20
+
+# Maximum number of candidate IPs to check per run.
+MAX_CANDIDATES = 500
+
+# Timeout in seconds for each DNS lookup.
+DNS_TIMEOUT = 2
+
+SOURCE_NAME = "rdns"
+
+
+class ReverseDNSCron(Cronjob):
+    """
+    Identify mass scanning services via reverse DNS lookups.
+
+    Runs daily, selects the top candidates most likely to be mass scanners
+    based on behavioral heuristics (persistent, no login attempts, low
+    interaction-to-attack ratio), resolves their PTR records in parallel,
+    and marks matches against a curated list of mass scanner domains.
+    Only IPs with actual PTR records are tagged, so IPs without records
+    are rechecked on subsequent runs.
+    """
+
+    def __init__(self, tag_repo=None, ioc_repo=None):
+        """
+        Initialize the cron job with repository dependencies.
+
+        Args:
+            tag_repo: Optional TagRepository instance for testing.
+            ioc_repo: Optional IocRepository instance for testing.
+        """
+        super().__init__()
+        self.tag_repo = tag_repo if tag_repo is not None else TagRepository()
+        self.ioc_repo = ioc_repo if ioc_repo is not None else IocRepository()
+
+    def run(self) -> None:
+        """
+        Perform reverse DNS lookups on the most probable scanner candidates.
+
+        1. Select top candidates using behavioral heuristics.
+        2. Resolve PTR records in parallel.
+        3. Store non-empty PTR results as tags.
+        4. Update reputation for IPs matching mass scanner domains.
+        """
+        candidates = self._get_candidates()
+
+        if not candidates:
+            self.log.info("No IOCs to check")
+            return
+
+        ip_to_id = {name: ioc_id for ioc_id, name in candidates}
+
+        # Resolve PTR records in parallel
+        ptr_results = self._resolve_batch(list(ip_to_id.keys()))
+
+        # Only tag IPs that have actual PTR records — IPs without PTR
+        # are left untagged so they can be rechecked on future runs.
+        tag_entries = []
+        total_matched = 0
+
+        for ip, ptr in ptr_results.items():
+            if not ptr:
+                continue
+
+            tag_entries.append({"ioc_id": ip_to_id[ip], "key": "ptr_record", "value": ptr})
+
+            if self._matches_scanner_domain(ptr):
+                self._update_ioc(ip)
+                total_matched += 1
+
+        created_count = self.tag_repo.add_tags(SOURCE_NAME, tag_entries)
+        self.log.info(f"Reverse DNS check completed. Checked {len(ptr_results)} IPs, created {created_count} tags, {total_matched} matched mass scanners")
+
+    def _get_candidates(self):
+        """
+        Select the top IOCs most likely to be mass scanners.
+
+        Behavioral heuristics:
+        - Seen on more than 2 distinct days (persistent presence)
+        - Zero login attempts (scanners don't try credentials)
+        - Low interaction-to-attack ratio (interaction_count < 2 * attack_count)
+        - No existing reputation classification
+        - Not already tagged by this source (already has PTR on file)
+
+        Returns the top MAX_CANDIDATES ordered by persistence.
+        """
+        return list(
+            IOC.objects.filter(
+                type=IocType.IP,
+                ip_reputation="",
+                number_of_days_seen__gt=2,
+                login_attempts=0,
+                interaction_count__lt=F("attack_count") * 2,
+            )
+            .exclude(tags__source=SOURCE_NAME)
+            .order_by("-number_of_days_seen")
+            .values_list("id", "name")
+            .distinct()[:MAX_CANDIDATES]
+        )
+
+    def _resolve_batch(self, ips: list[str]) -> dict[str, str]:
+        """
+        Resolve PTR records for a batch of IPs in parallel.
+
+        Sets an explicit socket timeout for the duration of the batch
+        and restores the previous value afterwards.  Each IP is resolved
+        independently — one failure does not affect the rest of the batch.
+
+        Args:
+            ips: List of IP addresses to resolve.
+
+        Returns:
+            Dict mapping IP address to PTR hostname (or empty string).
+        """
+        results = {}
+        old_timeout = socket.getdefaulttimeout()
+        socket.setdefaulttimeout(DNS_TIMEOUT)
+        try:
+            with ThreadPoolExecutor(max_workers=THREAD_POOL_SIZE) as executor:
+                future_to_ip = {executor.submit(self._resolve_ptr, ip): ip for ip in ips}
+                for future in as_completed(future_to_ip):
+                    ip = future_to_ip[future]
+                    try:
+                        results[ip] = future.result()
+                    except Exception:
+                        self.log.exception(f"Unexpected error resolving PTR for {ip}")
+                        results[ip] = ""
+        finally:
+            socket.setdefaulttimeout(old_timeout)
+        return results
+
+    def _resolve_ptr(self, ip: str) -> str:
+        """
+        Perform a reverse DNS lookup.
+
+        The socket timeout is set once by _resolve_batch before threads
+        are spawned, so all lookups share the configured DNS_TIMEOUT.
+
+        Args:
+            ip: IP address to resolve.
+
+        Returns:
+            The PTR hostname, or an empty string on any failure.
+        """
+        try:
+            hostname, _, _ = socket.gethostbyaddr(ip)
+            return hostname
+        except (socket.herror, socket.gaierror, TimeoutError, OSError):
+            return ""
+
+    @staticmethod
+    def _matches_scanner_domain(hostname: str) -> bool:
+        """
+        Check whether a PTR hostname belongs to a mass scanning service.
+
+        Args:
+            hostname: The resolved PTR record.
+
+        Returns:
+            True if the hostname matches a mass scanner domain.
+        """
+        hostname_lower = hostname.lower()
+        for domain in MASS_SCANNER_DOMAINS:
+            if hostname_lower == domain or hostname_lower.endswith("." + domain):
+                return True
+        return False
+
+    def _update_ioc(self, ip_address: str):
+        """
+        Update the IP reputation of an existing IOC to mark it as a mass scanner.
+
+        Args:
+            ip_address: IP address to update.
+        """
+        updated = self.ioc_repo.update_ioc_reputation(ip_address, "mass scanner")
+        if updated:
+            self.log.info(f"Marked {ip_address} as mass scanner via rDNS")

--- a/greedybear/cronjobs/schedules.py
+++ b/greedybear/cronjobs/schedules.py
@@ -71,6 +71,12 @@ def setup_schedules():
             "func": "greedybear.tasks.get_tor_exit_nodes",
             "cron": "7 1 * * 0",
         },
+        # 10. Reverse DNS Scanner Check: Daily at 06:07
+        {
+            "name": "check_reverse_dns",
+            "func": "greedybear.tasks.check_reverse_dns",
+            "cron": "7 6 * * *",
+        },
         # 11. ThreatFox Enrichment: Weekly (Sunday) at 01:07
         {
             "name": "enrich_threatfox",

--- a/greedybear/tasks.py
+++ b/greedybear/tasks.py
@@ -83,6 +83,12 @@ def get_tor_exit_nodes():
     TorExitNodesCron().execute()
 
 
+def check_reverse_dns():
+    from greedybear.cronjobs.reverse_dns import ReverseDNSCron
+
+    ReverseDNSCron().execute()
+
+
 def enrich_threatfox():
     from greedybear.cronjobs.threatfox_feed import ThreatFoxCron
 

--- a/tests/test_ioc_processor.py
+++ b/tests/test_ioc_processor.py
@@ -242,7 +242,7 @@ class TestMergeIocs(ExtractionTestCase):
 
         self.assertEqual(result.last_seen, new_time)
         self.assertEqual(result.first_seen, old_time)
-        self.assertEqual(result.ip_reputation, "new")
+        self.assertEqual(result.ip_reputation, "old")
         self.assertEqual(result.asn, 23)
 
     def test_last_seen_not_regressed(self):
@@ -274,6 +274,33 @@ class TestMergeIocs(ExtractionTestCase):
         result = self.processor._merge_iocs(existing, new)
 
         self.assertEqual(result.first_seen, earlier)
+
+    def test_preserves_reputation_when_new_is_empty(self):
+        """Existing ip_reputation must not be overwritten by an empty value."""
+        existing = self._create_mock_ioc(ip_reputation="mass scanner")
+        new = self._create_mock_ioc(ip_reputation="")
+
+        result = self.processor._merge_iocs(existing, new)
+
+        self.assertEqual(result.ip_reputation, "mass scanner")
+
+    def test_preserves_reputation_when_existing_is_set(self):
+        """Existing ip_reputation must not be overwritten even if new has a value."""
+        existing = self._create_mock_ioc(ip_reputation="tor exit node")
+        new = self._create_mock_ioc(ip_reputation="mass scanner")
+
+        result = self.processor._merge_iocs(existing, new)
+
+        self.assertEqual(result.ip_reputation, "tor exit node")
+
+    def test_fills_reputation_when_existing_is_empty(self):
+        """Empty existing ip_reputation should be filled by a non-empty new value."""
+        existing = self._create_mock_ioc(ip_reputation="")
+        new = self._create_mock_ioc(ip_reputation="mass scanner")
+
+        result = self.processor._merge_iocs(existing, new)
+
+        self.assertEqual(result.ip_reputation, "mass scanner")
 
     def test_handles_empty_urls_and_ports(self):
         existing = self._create_mock_ioc(related_urls=[], destination_ports=[])

--- a/tests/test_reverse_dns.py
+++ b/tests/test_reverse_dns.py
@@ -1,0 +1,376 @@
+import socket
+from datetime import date
+from unittest.mock import Mock, patch
+
+from greedybear.cronjobs import reverse_dns as reverse_dns_module
+from greedybear.cronjobs.reverse_dns import ReverseDNSCron
+from greedybear.models import IOC, IocType, Tag
+
+from . import CustomTestCase
+
+
+class TestReverseDNSCron(CustomTestCase):
+    """Test cases for ReverseDNSCron.run() — the main orchestrator."""
+
+    def setUp(self):
+        self.mock_tag_repo = Mock()
+        self.mock_ioc_repo = Mock()
+        self.cron = ReverseDNSCron(
+            tag_repo=self.mock_tag_repo,
+            ioc_repo=self.mock_ioc_repo,
+        )
+        self.cron.log = Mock()
+
+        # Create an IOC matching all behavioral heuristics:
+        # persistent (days_seen > 2), no logins, low interaction ratio
+        self.candidate_ioc = IOC.objects.create(
+            name="10.20.30.40",
+            type=IocType.IP.value,
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            days_seen=[date(2025, 1, 1), date(2025, 1, 2), date(2025, 1, 3)],
+            number_of_days_seen=3,
+            attack_count=10,
+            interaction_count=5,
+            ip_reputation="",
+            login_attempts=0,
+            destination_ports=[],
+            related_urls=[],
+        )
+
+    def tearDown(self):
+        IOC.objects.filter(name="10.20.30.40").delete()
+        Tag.objects.filter(source="rdns").delete()
+
+    def _mock_resolve(self, ptr_value):
+        """Return a side_effect for _resolve_batch that maps every IP to ptr_value."""
+        return lambda ips: dict.fromkeys(ips, ptr_value)
+
+    def test_eligible_ioc_is_resolved(self):
+        """An IOC matching behavioral heuristics should be resolved."""
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        mock_resolve.assert_called_once()
+        resolved_ips = mock_resolve.call_args[0][0]
+        self.assertIn(self.candidate_ioc.name, resolved_ips)
+
+    def test_skips_already_tagged_ips(self):
+        """IPs already tagged by rdns source should not be queried again."""
+        Tag.objects.create(ioc=self.candidate_ioc, key="ptr_record", value="scanner.shodan.io", source="rdns")
+
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        mock_resolve.assert_not_called()
+
+    def test_skips_ips_with_existing_reputation(self):
+        """IPs that already have a reputation should not be checked."""
+        IOC.objects.filter(name=self.candidate_ioc.name).update(ip_reputation="mass scanner")
+
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        mock_resolve.assert_not_called()
+
+    def test_skips_domain_type_iocs(self):
+        """Domain-type IOCs should not be checked (only IPs)."""
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        resolved_ips = mock_resolve.call_args[0][0]
+        self.assertNotIn("malicious.example.com", resolved_ips)
+
+    def test_skips_ips_with_few_days_seen(self):
+        """IPs seen on 2 or fewer days should not be candidates."""
+        IOC.objects.filter(name=self.candidate_ioc.name).update(number_of_days_seen=2)
+
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        mock_resolve.assert_not_called()
+
+    def test_skips_ips_with_login_attempts(self):
+        """IPs with login attempts are not mass scanners and should be skipped."""
+        IOC.objects.filter(name=self.candidate_ioc.name).update(login_attempts=1)
+
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        mock_resolve.assert_not_called()
+
+    def test_skips_ips_with_high_interaction_ratio(self):
+        """IPs with interaction_count >= 2 * attack_count should be skipped."""
+        IOC.objects.filter(name=self.candidate_ioc.name).update(attack_count=10, interaction_count=20)
+
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        mock_resolve.assert_not_called()
+
+    def test_stores_ptr_as_tag(self):
+        """Resolved PTR records should be stored as tags via add_tags."""
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("scanner.shodan.io")):
+            self.cron.run()
+
+        self.mock_tag_repo.add_tags.assert_called_once()
+        source, tag_entries = self.mock_tag_repo.add_tags.call_args[0]
+        self.assertEqual(source, "rdns")
+        self.assertEqual(len(tag_entries), 1)
+        self.assertEqual(tag_entries[0]["key"], "ptr_record")
+        self.assertEqual(tag_entries[0]["value"], "scanner.shodan.io")
+        self.assertEqual(tag_entries[0]["ioc_id"], self.candidate_ioc.id)
+
+    def test_does_not_store_empty_ptr(self):
+        """IPs with no PTR record should NOT be tagged, allowing rechecks."""
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")):
+            self.cron.run()
+
+        self.mock_tag_repo.add_tags.assert_called_once()
+        tag_entries = self.mock_tag_repo.add_tags.call_args[0][1]
+        self.assertEqual(len(tag_entries), 0)
+
+    def test_updates_reputation_on_scanner_match(self):
+        """Matching PTR should trigger a reputation update to 'mass scanner'."""
+        self.mock_ioc_repo.update_ioc_reputation.return_value = True
+
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("probe.censys.io")):
+            self.cron.run()
+
+        self.mock_ioc_repo.update_ioc_reputation.assert_called_with(self.candidate_ioc.name, "mass scanner")
+
+    def test_no_reputation_update_on_non_scanner_ptr(self):
+        """Non-scanner PTR records should not cause reputation updates."""
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("mail.google.com")):
+            self.cron.run()
+
+        self.mock_ioc_repo.update_ioc_reputation.assert_not_called()
+
+    def test_no_reputation_update_on_empty_ptr(self):
+        """Empty PTR results should not cause reputation updates."""
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")):
+            self.cron.run()
+
+        self.mock_ioc_repo.update_ioc_reputation.assert_not_called()
+
+    def test_candidates_ordered_by_persistence(self):
+        """Most persistent IPs should be checked first."""
+        more_persistent = IOC.objects.create(
+            name="10.20.30.41",
+            type=IocType.IP.value,
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            days_seen=[date(2025, 1, i) for i in range(1, 11)],
+            number_of_days_seen=10,
+            attack_count=100,
+            interaction_count=50,
+            ip_reputation="",
+            login_attempts=0,
+            destination_ports=[],
+            related_urls=[],
+        )
+
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        resolved_ips = mock_resolve.call_args[0][0]
+        idx_persistent = resolved_ips.index(more_persistent.name)
+        idx_candidate = resolved_ips.index(self.candidate_ioc.name)
+        self.assertLess(idx_persistent, idx_candidate)
+
+        more_persistent.delete()
+
+    def test_max_candidates_limit(self):
+        """No more than MAX_CANDIDATES should be checked per run."""
+        max_candidates = 3
+        extra_iocs = []
+        for i in range(max_candidates + 2):
+            ioc = IOC.objects.create(
+                name=f"10.0.{i}.1",
+                type=IocType.IP.value,
+                first_seen=self.current_time,
+                last_seen=self.current_time,
+                days_seen=[date(2025, 1, 1), date(2025, 1, 2), date(2025, 1, 3)],
+                number_of_days_seen=3,
+                attack_count=10,
+                interaction_count=5,
+                ip_reputation="",
+                login_attempts=0,
+                destination_ports=[],
+                related_urls=[],
+            )
+            extra_iocs.append(ioc)
+
+        with (
+            patch.object(reverse_dns_module, "MAX_CANDIDATES", max_candidates),
+            patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve,
+        ):
+            self.cron.run()
+
+        resolved_ips = mock_resolve.call_args[0][0]
+        self.assertLessEqual(len(resolved_ips), max_candidates)
+
+        for ioc in extra_iocs:
+            ioc.delete()
+
+    def test_fixture_iocs_excluded_by_behavioral_filters(self):
+        """Base fixture IOCs should not match (they have login_attempts=1, days_seen=1)."""
+        # Delete the candidate so only fixtures remain
+        self.candidate_ioc.delete()
+
+        with patch.object(self.cron, "_resolve_batch", side_effect=self._mock_resolve("")) as mock_resolve:
+            self.cron.run()
+
+        mock_resolve.assert_not_called()
+
+
+class TestReverseDNSCronResolveBatch(CustomTestCase):
+    """Tests for _resolve_batch — parallel PTR resolution."""
+
+    def setUp(self):
+        self.cron = ReverseDNSCron(tag_repo=Mock(), ioc_repo=Mock())
+
+    @patch("greedybear.cronjobs.reverse_dns.socket.gethostbyaddr")
+    def test_resolve_batch_returns_results_for_all_ips(self, mock_gethostbyaddr):
+        mock_gethostbyaddr.side_effect = lambda ip: (f"host-{ip}.example.com", [], [ip])
+
+        results = self.cron._resolve_batch(["1.2.3.4", "5.6.7.8"])
+
+        self.assertEqual(results["1.2.3.4"], "host-1.2.3.4.example.com")
+        self.assertEqual(results["5.6.7.8"], "host-5.6.7.8.example.com")
+
+    @patch("greedybear.cronjobs.reverse_dns.socket.gethostbyaddr")
+    def test_resolve_batch_handles_mixed_results(self, mock_gethostbyaddr):
+        def side_effect(ip):
+            if ip == "1.2.3.4":
+                return ("scanner.shodan.io", [], [ip])
+            raise socket.herror("Host not found")
+
+        mock_gethostbyaddr.side_effect = side_effect
+
+        results = self.cron._resolve_batch(["1.2.3.4", "5.6.7.8"])
+
+        self.assertEqual(results["1.2.3.4"], "scanner.shodan.io")
+        self.assertEqual(results["5.6.7.8"], "")
+
+    def test_resolve_batch_handles_unexpected_exception(self):
+        """An unexpected exception in one IP should not crash the batch."""
+        self.cron.log = Mock()
+
+        def bad_resolve(ip):
+            if ip == "1.2.3.4":
+                raise RuntimeError("unexpected")
+            return "host.example.com"
+
+        with patch.object(self.cron, "_resolve_ptr", side_effect=bad_resolve):
+            results = self.cron._resolve_batch(["1.2.3.4", "5.6.7.8"])
+
+        self.assertEqual(results["1.2.3.4"], "")
+        self.assertEqual(results["5.6.7.8"], "host.example.com")
+
+
+class TestReverseDNSCronResolvePTR(CustomTestCase):
+    """Tests for _resolve_ptr method."""
+
+    def setUp(self):
+        self.cron = ReverseDNSCron(tag_repo=Mock(), ioc_repo=Mock())
+
+    @patch("greedybear.cronjobs.reverse_dns.socket.gethostbyaddr")
+    def test_resolve_ptr_success(self, mock_gethostbyaddr):
+        mock_gethostbyaddr.return_value = ("scanner.shodan.io", [], ["1.2.3.4"])
+
+        result = self.cron._resolve_ptr("1.2.3.4")
+
+        self.assertEqual(result, "scanner.shodan.io")
+        mock_gethostbyaddr.assert_called_once_with("1.2.3.4")
+
+    @patch("greedybear.cronjobs.reverse_dns.socket.gethostbyaddr")
+    def test_resolve_ptr_herror(self, mock_gethostbyaddr):
+        mock_gethostbyaddr.side_effect = socket.herror("Host not found")
+
+        result = self.cron._resolve_ptr("1.2.3.4")
+
+        self.assertEqual(result, "")
+
+    @patch("greedybear.cronjobs.reverse_dns.socket.gethostbyaddr")
+    def test_resolve_ptr_timeout(self, mock_gethostbyaddr):
+        mock_gethostbyaddr.side_effect = TimeoutError("timed out")
+
+        result = self.cron._resolve_ptr("1.2.3.4")
+
+        self.assertEqual(result, "")
+
+    @patch("greedybear.cronjobs.reverse_dns.socket.gethostbyaddr")
+    def test_resolve_ptr_gaierror(self, mock_gethostbyaddr):
+        mock_gethostbyaddr.side_effect = socket.gaierror("Name resolution failed")
+
+        result = self.cron._resolve_ptr("1.2.3.4")
+
+        self.assertEqual(result, "")
+
+    @patch("greedybear.cronjobs.reverse_dns.socket.gethostbyaddr")
+    def test_resolve_ptr_oserror(self, mock_gethostbyaddr):
+        mock_gethostbyaddr.side_effect = OSError("Network unreachable")
+
+        result = self.cron._resolve_ptr("1.2.3.4")
+
+        self.assertEqual(result, "")
+
+
+class TestReverseDNSCronMatchesScannerDomain(CustomTestCase):
+    """Tests for _matches_scanner_domain static method."""
+
+    def test_exact_domain_match(self):
+        self.assertTrue(ReverseDNSCron._matches_scanner_domain("shodan.io"))
+
+    def test_subdomain_match(self):
+        self.assertTrue(ReverseDNSCron._matches_scanner_domain("scanner.shodan.io"))
+
+    def test_deep_subdomain_match(self):
+        self.assertTrue(ReverseDNSCron._matches_scanner_domain("a.b.censys.io"))
+
+    def test_case_insensitive_match(self):
+        self.assertTrue(ReverseDNSCron._matches_scanner_domain("Scanner.SHODAN.IO"))
+
+    def test_non_scanner_domain(self):
+        self.assertFalse(ReverseDNSCron._matches_scanner_domain("mail.google.com"))
+
+    def test_partial_name_no_match(self):
+        """A domain ending with a scanner name but not as a subdomain should not match."""
+        self.assertFalse(ReverseDNSCron._matches_scanner_domain("notshodan.io"))
+
+    def test_empty_hostname(self):
+        self.assertFalse(ReverseDNSCron._matches_scanner_domain(""))
+
+    def test_all_scanner_domains(self):
+        """Every domain in MASS_SCANNER_DOMAINS should match."""
+        from greedybear.consts import MASS_SCANNER_DOMAINS
+
+        for domain in MASS_SCANNER_DOMAINS:
+            self.assertTrue(ReverseDNSCron._matches_scanner_domain(domain), f"{domain} should match")
+            self.assertTrue(ReverseDNSCron._matches_scanner_domain(f"probe.{domain}"), f"probe.{domain} should match")
+
+
+class TestReverseDNSCronUpdateIoc(CustomTestCase):
+    """Tests for _update_ioc method."""
+
+    def setUp(self):
+        self.mock_ioc_repo = Mock()
+        self.cron = ReverseDNSCron(tag_repo=Mock(), ioc_repo=self.mock_ioc_repo)
+        self.cron.log = Mock()
+
+    def test_update_ioc_success(self):
+        self.mock_ioc_repo.update_ioc_reputation.return_value = True
+
+        self.cron._update_ioc("1.2.3.4")
+
+        self.mock_ioc_repo.update_ioc_reputation.assert_called_once_with("1.2.3.4", "mass scanner")
+        self.cron.log.info.assert_called_once()
+
+    def test_update_ioc_not_found(self):
+        self.mock_ioc_repo.update_ioc_reputation.return_value = False
+
+        self.cron._update_ioc("9.9.9.9")
+
+        self.mock_ioc_repo.update_ioc_reputation.assert_called_once_with("9.9.9.9", "mass scanner")
+        self.cron.log.info.assert_not_called()

--- a/tests/test_tag_repository.py
+++ b/tests/test_tag_repository.py
@@ -85,6 +85,37 @@ class TestTagRepository(CustomTestCase):
         self.assertEqual(Tag.objects.filter(source="threatfox").count(), 0)
         self.assertEqual(Tag.objects.filter(source="abuseipdb").count(), 1)
 
+    def test_add_tags_creates_tags(self):
+        """Should create new tags without removing existing ones."""
+        tag_entries = [
+            {"ioc_id": self.ioc.id, "key": "ptr_record", "value": "scanner.shodan.io"},
+            {"ioc_id": self.ioc_2.id, "key": "ptr_record", "value": "probe.censys.io"},
+        ]
+
+        count = self.repo.add_tags("rdns", tag_entries)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(Tag.objects.filter(source="rdns").count(), 2)
+
+    def test_add_tags_preserves_existing_tags(self):
+        """Should not delete existing tags from the same source."""
+        Tag.objects.create(ioc=self.ioc, key="ptr_record", value="old.example.com", source="rdns")
+
+        tag_entries = [
+            {"ioc_id": self.ioc_2.id, "key": "ptr_record", "value": "new.example.com"},
+        ]
+
+        self.repo.add_tags("rdns", tag_entries)
+
+        self.assertEqual(Tag.objects.filter(source="rdns").count(), 2)
+
+    def test_add_tags_with_empty_list_returns_zero(self):
+        """Should return 0 and create nothing when given an empty list."""
+        count = self.repo.add_tags("rdns", [])
+
+        self.assertEqual(count, 0)
+        self.assertEqual(Tag.objects.filter(source="rdns").count(), 0)
+
     def test_tags_deleted_when_ioc_deleted(self):
         """Tags should be cascade deleted when their IOC is deleted."""
         Tag.objects.create(ioc=self.ioc, key="malware", value="Mirai", source="threatfox")


### PR DESCRIPTION

  # Description

  Add a daily reverse DNS cron job that identifies IPs belonging to known scanning
  services (Shodan, Censys, Onyphe, etc.) and marks them as "known scanner" via
  `ip_reputation`. This implements step 2 of #527 — rDNS-based filtering,
  decoupled from the extraction pipeline.

  **What it does:**
  - Queries IOCs with empty `ip_reputation` seen in the last 24h
  - Resolves PTR records with a 2s timeout per IP
  - Caches all results in a `ReverseDNSRecord` table (so IPs are never re-queried)
  - Matches PTR hostnames against a curated `KNOWN_SCANNER_DOMAINS` list
  - Updates matching IOCs to `ip_reputation = "known scanner"`
  - Feeds exclude "known scanner" by default (same pattern as mass scanner / tor exit node)

  Also fixes `_merge_iocs()` to only overwrite `ip_reputation` when empty, preventing
  extraction from wiping out reputation set by enrichment crons (discussed in #527).

  ### Related issues

  - Closes #527 (step 2: rDNS-based filtering)
  - Builds on #541 (step 1: mass scanner list)

  ### Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue).
  - [x] New feature (non-breaking change which adds functionality).
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
  - [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

  # Checklist

  ### Formalities

  - [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
  - [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
  - [x] My branch is based on `develop`.
  - [x] The pull request is for the branch `develop`.
  - [x] I have reviewed and verified any LLM-generated code included in this PR.

  ### Docs and tests

  - [x] I documented my code changes with docstrings and/or comments.
  - [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the
  [docs repository](https://github.com/intelowlproject/docs).
  - [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does
  these checks and adjustments on your behalf.
  - [x] I have added tests for the feature/bug I solved.
  - [x] All the tests gave 0 errors.

  ### GUI changes

  Ignore this section if you did not make any changes to the GUI.

  - [ ] I have provided a screenshot of the result in the PR.
  - [ ] I have created new frontend tests for the new component or updated existing ones.

