### PR TITLE
fix : remove redundant nested Suspense wrappers in Routes.jsx

### DIFF
--- a/frontend/src/components/Routes.jsx
+++ b/frontend/src/components/Routes.jsx
@@ -22,29 +22,17 @@ const publicRoutesLazy = [
   /* Home */
   {
     index: true,
-    element: (
-      <Suspense fallback={<FallBackLoading />}>
-        <Home />
-      </Suspense>
-    ),
+    element: <Home />,
   },
   /* Dashboard */
   {
     path: "/dashboard",
-    element: (
-      <Suspense fallback={<FallBackLoading />}>
-        <Dashboard />
-      </Suspense>
-    ),
+    element: <Dashboard />,
   },
   /* Feeds */
   {
     path: "/feeds",
-    element: (
-      <Suspense fallback={<FallBackLoading />}>
-        <Feeds />
-      </Suspense>
-    ),
+    element: <Feeds />,
   },
 ].map((r) => ({
   ...r,
@@ -83,29 +71,17 @@ const authRoutesLazy = [
   /* auth */
   {
     path: "/logout",
-    element: (
-      <Suspense fallback={<FallBackLoading />}>
-        <Logout />
-      </Suspense>
-    ),
+    element: <Logout />,
   },
   /* API Access/Sessions Management */
   {
     path: "/me/sessions",
-    element: (
-      <Suspense fallback={<FallBackLoading />}>
-        <Sessions />
-      </Suspense>
-    ),
+    element: <Sessions />,
   },
   /* Change Password */
   {
     path: "/me/change-password",
-    element: (
-      <Suspense fallback={<FallBackLoading />}>
-        <ChangePassword />
-      </Suspense>
-    ),
+    element: <ChangePassword />,
   },
 ].map((r) => ({
   ...r,


### PR DESCRIPTION
# Description
Removed redundant nested `<Suspense>` wrappers in `Routes.jsx`. 
The `publicRoutesLazy` and `authRoutesLazy` arrays were defining 
route elements already wrapped in `<Suspense>`, and then the `.map()` 
at the end was wrapping them in another `<Suspense>`. This removes 
the inner wrappers and lets the `.map()` handle the single Suspense 
boundary for each route group.

 
### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).



### Formalities
- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests
- [x] I documented my code changes with docstrings and/or comments.
- [X] I have checked if my changes affect user-facing behavior that is described in the docs. 
- [ ] I have added tests for the feature/bug I solved.
- [ ] All the tests gave 0 errors.

No tests added — this is a pure refactor with no functional changes.
All routes verified manually in the browser.

Closes #957 