### PR TITLE
fix: return empty list instead of empty dict in load_training_data

### DIFF
--- a/greedybear/cronjobs/scoring/scoring_jobs.py
+++ b/greedybear/cronjobs/scoring/scoring_jobs.py
@@ -65,7 +65,7 @@ class TrainModels(Cronjob):
         Load previously saved IoC data from storage.
 
         Returns:
-            list: Previously stored IoC data, or empty dict if loading fails.
+            list: Previously stored IoC data, or empty list if loading fails.
         """
         self.log.info("loading training data from file system")
         try:
@@ -73,7 +73,7 @@ class TrainModels(Cronjob):
                 return json.load(file)
         except Exception as exc:
             self.log.error(f"error loading training data: {exc}")
-            return {}
+            return []
 
     def run(self):
         """


### PR DESCRIPTION
# Description
I noticed that load_training_data() in scoring_jobs.py returns {} (empty dict) when loading fails, but the function signature says it returns list[dict] and the happy path returns a list from json.load(). The docstring also said "empty dict". I changed the fallback to return [] and updated the docstring to say "empty list" so everything is consistent with the declared return type.
closes #965

### Type of change

- [x ] Bug fix (non-breaking change which fixes an issue).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [ ] All the tests gave 0 errors.