### PR TITLE
feat: add github and linkedin links to app footer

### DIFF
--- a/frontend/src/layouts/AppFooter.jsx
+++ b/frontend/src/layouts/AppFooter.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Row, Col, Container } from "reactstrap";
-import { FaTwitter } from "react-icons/fa";
+import { FaXTwitter, FaGithub, FaLinkedin } from "react-icons/fa6";
 
 import { ScrollToTopButton, Toaster, useToastr } from "@certego/certego-ui";
 
@@ -25,27 +25,41 @@ function AppFooter() {
           ))}
         </section>
         {/* Footer */}
-        <Container fluid className="border-top mt-2 py-1">
-          <Row
-            md={12}
-            lg={8}
-            className="g-0 d-flex-center flex-column flex-lg-row text-center lead"
-          >
-            <Col className="text-muted small">{VERSION}</Col>
-          </Row>
-          <Row
-            md={12}
-            className="g-0 mt-3 d-flex-center flex-column flex-lg-row text-center"
-          >
-            <Col>
+        <Container fluid className="border-top mt-2 py-3">
+          <Row className="align-items-center">
+            <Col md={12} className="text-center">
+              <span className="text-white px-2 py-1 rounded">
+                Follow us on:
+              </span>
               <a
                 href="https://twitter.com/intel_owl"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="ms-md-2 twitter-follow-button"
+                className="ms-3 text-white text-decoration-none"
               >
-                <FaTwitter /> Follow @intel_owl
+                <FaXTwitter size={20} />
               </a>
+              <a
+                href="https://github.com/intelowlproject"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ms-3 text-white text-decoration-none"
+              >
+                <FaGithub size={20} />
+              </a>
+              <a
+                href="https://www.linkedin.com/company/intelowl/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ms-3 text-white text-decoration-none"
+              >
+                <FaLinkedin size={20} />
+              </a>
+            </Col>
+          </Row>
+          <Row className="mt-2">
+            <Col className="text-center">
+              <small className="text-muted">{VERSION}</small>
             </Col>
           </Row>
         </Container>

--- a/frontend/src/styles/App.scss
+++ b/frontend/src/styles/App.scss
@@ -100,7 +100,7 @@ section.fixed-bottom {
   overflow-y: auto;
 }
 
-.twitter-follow-button {
+.link-follow-button {
   /* stylelint-disable scss/at-extend-no-missing-placeholder */
   @extend .btn;
   @extend .btn-xs;


### PR DESCRIPTION
# Description

This pull request updates the application footer by adding GitHub and LinkedIn social media links alongside the existing Twitter link. It also restructures the footer layout for a cleaner and more organized appearance.

The footer now displays the project copyright on the left side and social media icons aligned horizontally on the right side.

### Related issues

#979 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [ ] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Before:
<img width="1872" height="125" alt="image" src="https://github.com/user-attachments/assets/01874f40-d6b9-4ca3-9eb5-0e097515fc74" />

After:
<img width="1907" height="178" alt="image" src="https://github.com/user-attachments/assets/2cbf3a78-049a-4f28-89ff-6b8a1e3d465b" />