### PR TITLE
test: add tests for AuthGuard and IfAuthRedirectGuard

### DIFF
--- a/frontend/tests/wrapper/AuthGuard.test.jsx
+++ b/frontend/tests/wrapper/AuthGuard.test.jsx
@@ -4,6 +4,7 @@ import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import AuthGuard from "../../src/wrappers/AuthGuard";
 import { AUTHENTICATION_STATUSES } from "../../src/constants";
+import { addToast } from "@certego/certego-ui";
 
 const mockUseAuthStore = vi.fn();
 vi.mock("../../src/stores", () => ({
@@ -76,12 +77,6 @@ describe("AuthGuard", () => {
       selector({ isAuthenticated: AUTHENTICATION_STATUSES.FALSE }),
     );
 
-    let capturedLocation;
-    const LocationCapture = () => {
-      capturedLocation = window.location.href;
-      return <div>Login Page</div>;
-    };
-
     render(
       <MemoryRouter initialEntries={["/me/sessions"]}>
         <Routes>
@@ -93,13 +88,18 @@ describe("AuthGuard", () => {
               </AuthGuard>
             }
           />
-          <Route path="/login" element={<LocationCapture />} />
+          <Route path="/login" element={<div>Login Page</div>} />
         </Routes>
       </MemoryRouter>,
     );
 
     expect(screen.getByText("Login Page")).toBeInTheDocument();
     expect(screen.queryByText("Protected Content")).not.toBeInTheDocument();
+    expect(addToast).toHaveBeenCalledWith(
+      "Login required to access the requested page.",
+      null,
+      "info",
+    );
   });
 
   test("redirects to / when user visits /logout while unauthenticated", () => {
@@ -126,5 +126,6 @@ describe("AuthGuard", () => {
 
     expect(screen.getByText("Home Page")).toBeInTheDocument();
     expect(screen.queryByText("Login Page")).not.toBeInTheDocument();
+    expect(addToast).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/wrapper/IfAuthRedirectGuard.test.jsx
+++ b/frontend/tests/wrapper/IfAuthRedirectGuard.test.jsx
@@ -5,13 +5,11 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { AUTHENTICATION_STATUSES } from "../../src/constants";
 import IfAuthRedirectGuard from "../../src/wrappers/ifAuthRedirectGuard";
 
-// Mock useAuthStore
 const mockUseAuthStore = vi.fn();
 vi.mock("../../src/stores", () => ({
   useAuthStore: (selector) => mockUseAuthStore(selector),
 }));
 
-// Mock useSearchParam at top level
 const mockUseSearchParam = vi.fn();
 vi.mock("react-use/lib/useSearchParam", () => ({
   default: () => mockUseSearchParam(),
@@ -20,7 +18,7 @@ vi.mock("react-use/lib/useSearchParam", () => ({
 describe("IfAuthRedirectGuard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUseSearchParam.mockReturnValue(null); // default: no next param
+    mockUseSearchParam.mockReturnValue(null);
   });
 
   test("renders children when user is not authenticated", () => {
@@ -50,7 +48,7 @@ describe("IfAuthRedirectGuard", () => {
     mockUseAuthStore.mockImplementation((selector) =>
       selector({ isAuthenticated: AUTHENTICATION_STATUSES.TRUE }),
     );
-    mockUseSearchParam.mockReturnValue(null); // no next param
+    mockUseSearchParam.mockReturnValue(null);
 
     render(
       <MemoryRouter initialEntries={["/login"]}>
@@ -76,7 +74,7 @@ describe("IfAuthRedirectGuard", () => {
     mockUseAuthStore.mockImplementation((selector) =>
       selector({ isAuthenticated: AUTHENTICATION_STATUSES.TRUE }),
     );
-    mockUseSearchParam.mockReturnValue("/dashboard"); // next param set
+    mockUseSearchParam.mockReturnValue("/dashboard");
 
     render(
       <MemoryRouter initialEntries={["/login?next=/dashboard"]}>


### PR DESCRIPTION
# Description
Added tests for `AuthGuard` and `IfAuthRedirectGuard` routing guards 
which previously had zero test coverage. 



### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).


### Formalities
- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests
- [ ] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior.
- [X] Linter (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes
No GUI changes — test coverage  only.

### Tests added

**AuthGuard (4 tests):**
- Shows loading indicator when authentication status is pending
- Renders children when user is authenticated
- Redirects unauthenticated user to /login with ?next param
- Redirects to / instead of /login when user visits /logout

**IfAuthRedirectGuard (3 tests):**
- Renders children when user is not authenticated
- Redirects authenticated user from /login to / when no next param
- Redirects authenticated user to ?next param when provided


Also Ran the test Locally
<img width="660" height="213" alt="image" src="https://github.com/user-attachments/assets/2570762a-170f-4cb4-b2fa-fd2e244bad29" />


---

Closes #972 