### PR TITLE
Expose IoC-Sensor relationship in API. Closes #781

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -22,6 +22,12 @@ class GeneralHoneypotSerializer(serializers.ModelSerializer):
 class IOCSerializer(serializers.ModelSerializer):
     general_honeypot = GeneralHoneypotSerializer(many=True, read_only=True)
 
+    sensors = serializers.SlugRelatedField(
+        many=True,
+        read_only=True,
+        slug_field="address"
+    )
+
     class Meta:
         model = IOC
         exclude = [


### PR DESCRIPTION
**Description**
This PR addresses the requirement to expose the relationship between Indicators of Compromise (IoCs) and their reporting Sensors in the API responses. By updating the IOCSerializer, we now include a sensors field that lists the addresses of all sensors associated with a specific IoC. This provides better visibility for security analysts using the Enrichment and Feeds APIs.

**Related issues**
Closes #781

**Type of change**
[x] New feature (non-breaking change which adds functionality).

**Checklist
Formalities**
[x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.

[x] I chose an appropriate title for the pull request in the form: Expose IoC-Sensor relationship in API. Closes #781

[x] My branch is based on develop.

[x] The pull request is for the branch develop.

[x] I have reviewed and verified any LLM-generated code included in this PR.

**Docs and tests**
[x] I documented my code changes with docstrings and/or comments.
[x] I have checked if my changes affect user-facing behavior.
[x] Linter (Ruff) gave 0 errors.
[x] I have verified the changes manually using the Django shell in the Docker environment.

**Verification Proof (Manual Testing)**
I verified the serializer output within the Docker uwsgi container:

_Python
>>> from api.serializers import IOCSerializer
>>> from greedybear.models import IOC, Sensor
>>> s, _ = Sensor.objects.get_or_create(address="10.0.0.1")
>>> i, _ = IOC.objects.get_or_create(name="1.2.3.4", type="ip")
>>> i.sensors.add(s)
>>> data = IOCSerializer(i).data
>>> print(data['sensors'])
['10.0.0.1']_

<img width="954" height="148" alt="Screenshot 2026-03-06 235642" src="https://github.com/user-attachments/assets/fa724072-b34b-4609-bc0b-7b887529a73e" />
