### PR TITLE
Fix include_similar in command_sequence_view to union instead of replace. Closes #985

### DIFF
--- a/api/views/command_sequence.py
+++ b/api/views/command_sequence.py
@@ -68,7 +68,8 @@ def command_sequence_view(request):
         related_iocs = IOC.objects.filter(cowriesession__commands__in=sequences).distinct().only("name")
         if include_similar:
             related_clusters = {s.cluster for s in sequences if s.cluster is not None}
-            related_iocs = IOC.objects.filter(cowriesession__commands__cluster__in=related_clusters).distinct().only("name")
+            cluster_iocs = IOC.objects.filter(cowriesession__commands__cluster__in=related_clusters).distinct().only("name")
+            related_iocs = related_iocs.union(cluster_iocs)
         if not seqs:
             raise Http404(f"No command sequences found for IP: {observable}")
         data = {


### PR DESCRIPTION
# Description

When querying `command_sequence_view` by IP with `include_similar=true`, `related_iocs` is reassigned instead of extended, silently dropping the base exact-match results.

The `include_similar` flag at lines 69-71 of `api/views/command_sequence.py` replaces `related_iocs` with a cluster-based query instead of extending it. This causes two problems:

1. If none of the matched command sequences have a cluster, `related_clusters` is empty, the query returns nothing, and `executed_by` becomes `[]` — even though without `include_similar` it would have returned real data.
2. Even when clusters exist, the IOCs from the original exact-match query are lost if they do not also appear in the cluster-based query.

The fix uses `.union()` to combine the base exact-match results with the cluster-based results, matching the correct pattern already used in `cowrie_session_view` (lines 96-100).

### Related issues

Closes #985

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.