### PR TITLE
fix: union instead of replace for include_similar in command_sequence…

### DIFF
--- a/api/views/command_sequence.py
+++ b/api/views/command_sequence.py
@@ -68,7 +68,9 @@ def command_sequence_view(request):
         related_iocs = IOC.objects.filter(cowriesession__commands__in=sequences).distinct().only("name")
         if include_similar:
             related_clusters = {s.cluster for s in sequences if s.cluster is not None}
-            related_iocs = IOC.objects.filter(cowriesession__commands__cluster__in=related_clusters).distinct().only("name")
+            if related_clusters:
+                cluster_iocs = IOC.objects.filter(cowriesession__commands__cluster__in=related_clusters).distinct().only("name")
+                related_iocs = related_iocs.union(cluster_iocs)
         if not seqs:
             raise Http404(f"No command sequences found for IP: {observable}")
         data = {

--- a/tests/api/views/test_command_sequence_view.py
+++ b/tests/api/views/test_command_sequence_view.py
@@ -36,6 +36,42 @@ class CommandSequenceViewTestCase(CustomTestCase):
         self.assertIn("executed_commands", response.data)
         self.assertIn("executed_by", response.data)
 
+    def test_include_similar_preserves_base_results(self):
+        """Test that include_similar extends executed_by instead of replacing it."""
+        # Get base results without include_similar
+        base_response = self.client.get("/api/command_sequence?query=140.246.171.141")
+        self.assertEqual(base_response.status_code, 200)
+        base_executed_by = set(base_response.data["executed_by"])
+
+        # Get results with include_similar
+        similar_response = self.client.get("/api/command_sequence?query=140.246.171.141&include_similar")
+        self.assertEqual(similar_response.status_code, 200)
+        similar_executed_by = set(similar_response.data["executed_by"])
+
+        # include_similar should be a superset of base results, never lose them
+        self.assertTrue(
+            base_executed_by.issubset(similar_executed_by),
+            f"include_similar lost base results: {base_executed_by - similar_executed_by}",
+        )
+
+    def test_include_similar_with_unclustered_sequences(self):
+        """Test that include_similar still returns results when sequences have no cluster."""
+        # Remove cluster from the command sequence
+        self.command_sequence.cluster = None
+        self.command_sequence.save()
+
+        base_response = self.client.get("/api/command_sequence?query=140.246.171.141")
+        self.assertEqual(base_response.status_code, 200)
+
+        similar_response = self.client.get("/api/command_sequence?query=140.246.171.141&include_similar")
+        self.assertEqual(similar_response.status_code, 200)
+
+        # When no clusters exist, include_similar should still return the base results
+        self.assertEqual(
+            base_response.data["executed_by"],
+            similar_response.data["executed_by"],
+        )
+
     def test_nonexistent_ip_address(self):
         """Test that view returns 404 for IP with no sequences."""
         response = self.client.get("/api/command_sequence?query=10.0.0.1")


### PR DESCRIPTION
# Description

I found a bug in the command sequence API where using `include_similar=true` actually made the results worse instead of better , it was losing data instead of extending it.

The problem: when I query an IP with `include_similar=true`, the API was throwing away the exact matches and only returning cluster-based results. If a command sequence had no cluster assigned, I'd get nothing back even though there should be results.

  ## What I Changed

  I rewrote lines 69-73 in `command_sequence_view` to use `.union()` instead of reassigning the queryset. This matches how
  `cowrie_session_view` already handles the same flag correctly.

  ## Tests

  Added two tests to catch this regression:
  - One verifies `include_similar` results include the base results (never lose data)
  - One tests the edge case where sequences have no cluster

 ## Fixes #985

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.