### PR TITLE
Tests: Add test coverage for celery tasks in `greedybear/tasks.py`. Closes #995

### DIFF
--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -60,3 +60,95 @@ class TestExtractAllTrainingTrigger(CustomTestCase):
 
         mock_job().execute.assert_called_once()
         mock_train.assert_not_called()
+
+
+class TestOtherTasks(CustomTestCase):
+    """Test the other tasks in greedybear/tasks.py."""
+
+    @patch("greedybear.cronjobs.monitor_honeypots.MonitorHoneypots.execute")
+    def test_monitor_honeypots(self, mock_execute):
+        from greedybear.tasks import monitor_honeypots
+
+        monitor_honeypots()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.cronjobs.monitor_logs.MonitorLogs.execute")
+    def test_monitor_logs(self, mock_execute):
+        from greedybear.tasks import monitor_logs
+
+        monitor_logs()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.cronjobs.scoring.scoring_jobs.TrainModels.execute")
+    @patch("greedybear.cronjobs.scoring.scoring_jobs.UpdateScores.execute")
+    def test_train_and_update(self, mock_update_execute, mock_train_execute):
+        from greedybear.tasks import train_and_update
+
+        train_and_update()
+        mock_train_execute.assert_called_once()
+        mock_update_execute.assert_called_once()
+
+    @patch("greedybear.tasks.CLUSTER_COWRIE_COMMAND_SEQUENCES", True)
+    @patch("greedybear.cronjobs.commands.cluster.ClusterCommandSequences.execute")
+    def test_cluster_commands_enabled(self, mock_execute):
+        from greedybear.tasks import cluster_commands
+
+        cluster_commands()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.tasks.CLUSTER_COWRIE_COMMAND_SEQUENCES", False)
+    @patch("greedybear.cronjobs.commands.cluster.ClusterCommandSequences.execute")
+    def test_cluster_commands_disabled(self, mock_execute):
+        from greedybear.tasks import cluster_commands
+
+        cluster_commands()
+        mock_execute.assert_not_called()
+
+    @patch("greedybear.cronjobs.cleanup.CleanUp.execute")
+    def test_clean_up_db(self, mock_execute):
+        from greedybear.tasks import clean_up_db
+
+        clean_up_db()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.cronjobs.mass_scanners.MassScannersCron.execute")
+    def test_get_mass_scanners(self, mock_execute):
+        from greedybear.tasks import get_mass_scanners
+
+        get_mass_scanners()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.cronjobs.whatsmyip.WhatsMyIPCron.execute")
+    def test_get_whatsmyip(self, mock_execute):
+        from greedybear.tasks import get_whatsmyip
+
+        get_whatsmyip()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.cronjobs.firehol.FireHolCron.execute")
+    def test_extract_firehol_lists(self, mock_execute):
+        from greedybear.tasks import extract_firehol_lists
+
+        extract_firehol_lists()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.cronjobs.tor_exit_nodes.TorExitNodesCron.execute")
+    def test_get_tor_exit_nodes(self, mock_execute):
+        from greedybear.tasks import get_tor_exit_nodes
+
+        get_tor_exit_nodes()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.cronjobs.threatfox_feed.ThreatFoxCron.execute")
+    def test_enrich_threatfox(self, mock_execute):
+        from greedybear.tasks import enrich_threatfox
+
+        enrich_threatfox()
+        mock_execute.assert_called_once()
+
+    @patch("greedybear.cronjobs.abuseipdb_feed.AbuseIPDBCron.execute")
+    def test_enrich_abuseipdb(self, mock_execute):
+        from greedybear.tasks import enrich_abuseipdb
+
+        enrich_abuseipdb()
+        mock_execute.assert_called_once()


### PR DESCRIPTION
# Description

This PR adds test coverage for all 10 remaining untested celery task wrappers in `greedybear/tasks.py`. Previously, the file only had 41% test coverage inline. By adding isolated tests using `unittest.mock.patch` for each cronjob's `execute` invocation inside `tests/test_tasks.py`, we bring the file up to 100% coverage.

### Related issues

Closes #995

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.
