### PR TITLE
Add slack tests

### DIFF
--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+from greedybear.slack import send_slack_message
+from tests import CustomTestCase
+
+TEST_LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": True,
+}
+
+
+@override_settings(LOGGING=TEST_LOGGING)
+class SendSlackMessageTests(CustomTestCase):
+    @override_settings(SLACK_TOKEN="")
+    @patch("greedybear.slack.WebClient")
+    @patch("greedybear.slack.logger")
+    def test_no_token_configured_logs_warning_and_skips(self, mock_logger, mock_webclient):
+        send_slack_message("hello")
+
+        mock_webclient.assert_not_called()
+        mock_logger.warning.assert_called_once_with("Slack is not configured, message not sent")
+
+    @override_settings(SLACK_TOKEN="xoxb-test-token", DEFAULT_SLACK_CHANNEL="#alerts")
+    @patch("greedybear.slack.WebClient")
+    @patch("greedybear.slack.logger")
+    def test_message_sent_successfully(self, mock_logger, mock_webclient):
+        mock_client = MagicMock()
+        mock_webclient.return_value = mock_client
+
+        send_slack_message("test alert")
+
+        mock_webclient.assert_called_once_with(token="xoxb-test-token")
+        mock_client.chat_postMessage.assert_called_once_with(channel="#alerts", text="test alert", mrkdwn=True)
+        mock_logger.exception.assert_not_called()
+
+    @override_settings(SLACK_TOKEN="xoxb-test-token", DEFAULT_SLACK_CHANNEL="#alerts")
+    @patch("greedybear.slack.WebClient")
+    @patch("greedybear.slack.logger")
+    def test_exception_is_logged_but_not_raised(self, mock_logger, mock_webclient):
+        error = Exception("Slack API error")
+        mock_client = MagicMock()
+        mock_client.chat_postMessage.side_effect = error
+        mock_webclient.return_value = mock_client
+
+        send_slack_message("test alert")
+
+        mock_logger.exception.assert_called_once_with(error)


### PR DESCRIPTION
**Title:** `tests: add test coverage for greedybear/slack.py. Closes #977`

# Description

Adds test_slack.py to bring slack.py from 33% to 100% coverage. Closes #977.

### Related issues

- Closes #977

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [ ] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

N/A — no frontend changes.
