### PR TITLE
fix(extraction): add sort guard to _update_days_seen to prevent corrupted days_seen ordering. Closes #1007

### DIFF
--- a/greedybear/cronjobs/extraction/ioc_processor.py
+++ b/greedybear/cronjobs/extraction/ioc_processor.py
@@ -128,7 +128,9 @@ class IocProcessor:
         Returns:
             The updated IOC record.
         """
-        if len(ioc.days_seen) == 0 or ioc.days_seen[-1] != ioc.last_seen.date():
-            ioc.days_seen.append(ioc.last_seen.date())
-            ioc.number_of_days_seen = len(ioc.days_seen)
+        new_date = ioc.last_seen.date()
+        if new_date not in ioc.days_seen:
+            ioc.days_seen.append(new_date)
+            ioc.days_seen.sort()
+        ioc.number_of_days_seen = len(ioc.days_seen)
         return ioc

--- a/tests/test_ioc_processor.py
+++ b/tests/test_ioc_processor.py
@@ -370,3 +370,48 @@ class TestUpdateDaysSeen(ExtractionTestCase):
         result.last_seen = datetime(2025, 1, 2, 0, 0, 0)
         result = self.processor._update_days_seen(result)
         self.assertEqual(len(result.days_seen), 2)
+
+    def test_sort_guard_non_chronological(self):
+        """Sort guard heals non-chronological days_seen."""
+        ioc = self._create_mock_ioc(
+            last_seen=datetime(2025, 1, 4, 12, 0, 0),
+        )
+        ioc.days_seen = [date(2025, 1, 5)]
+        ioc.number_of_days_seen = 1
+
+        result = self.processor._update_days_seen(ioc)
+
+        self.assertEqual(
+            result.days_seen,
+            [date(2025, 1, 4), date(2025, 1, 5)],
+        )
+        self.assertEqual(result.number_of_days_seen, 2)
+
+    def test_sort_guard_adjacent_day_reversal(self):
+        """Adjacent-day reversal is sorted — no ZeroDivisionError path."""
+        ioc = self._create_mock_ioc(
+            last_seen=datetime(2025, 1, 4, 23, 58, 0),
+        )
+        ioc.days_seen = [date(2025, 1, 5)]
+        ioc.number_of_days_seen = 1
+
+        result = self.processor._update_days_seen(ioc)
+
+        self.assertEqual(
+            result.days_seen,
+            [date(2025, 1, 4), date(2025, 1, 5)],
+        )
+        self.assertEqual(result.number_of_days_seen, 2)
+
+    def test_sort_guard_no_duplicate(self):
+        """Duplicate date is not appended."""
+        ioc = self._create_mock_ioc(
+            last_seen=datetime(2025, 1, 5, 10, 0, 0),
+        )
+        ioc.days_seen = [date(2025, 1, 5)]
+        ioc.number_of_days_seen = 1
+
+        result = self.processor._update_days_seen(ioc)
+
+        self.assertEqual(len(result.days_seen), 1)
+        self.assertEqual(result.number_of_days_seen, 1)


### PR DESCRIPTION
# Description

`_update_days_seen()` only checked the tail element (`days_seen[-1]`) before appending, which prevented consecutive duplicates but not non-chronological entries. Before #974, `last_seen` could regress when a later-processed honeypot had an earlier timestamp — if that regression crossed a date boundary, `_update_days_seen()` appended dates out of order (e.g. `[..., Jan 5, Jan 4]`).

This corrupts the ML scoring pipeline at `scoring/utils.py:71`, where `time_diffs` is computed assuming ascending `days_seen`. Reversed entries produce negative diffs → negative `active_timespan` → wrong `active_days_ratio`. In the adjacent-day case (`[Jan 5, Jan 4]`), `active_timespan` hits 0 and causes a `ZeroDivisionError` at line 91.

Changes:
- Replaced `days_seen[-1] != new_date` tail check with `new_date not in days_seen` membership check (also catches non-consecutive duplicates)
- Added `ioc.days_seen.sort()` after append to enforce chronological order
- Moved `number_of_days_seen` update outside the `if` block so it always stays in sync

### Related issues

Closes #1007

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [ ] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

No GUI changes.