### PR TITLE
Eliminates N+1 queries in the IOC extraction pipeline

### DIFF
--- a/greedybear/cronjobs/extraction/ioc_processor.py
+++ b/greedybear/cronjobs/extraction/ioc_processor.py
@@ -1,9 +1,8 @@
 import logging
 
 from greedybear.consts import PAYLOAD_REQUEST, SCANNER
-from greedybear.cronjobs.extraction.utils import is_whatsmyip_domain
 from greedybear.cronjobs.repositories import IocRepository, SensorRepository
-from greedybear.models import IOC, IocType
+from greedybear.models import IOC, IocType, WhatsMyIPDomain
 
 
 class IocProcessor:
@@ -25,6 +24,7 @@ class IocProcessor:
         self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
         self.ioc_repo = ioc_repo
         self.sensor_repo = sensor_repo
+        self._whatsmyip_domains = set(WhatsMyIPDomain.objects.values_list("domain", flat=True))
 
     def add_ioc(
         self,
@@ -52,7 +52,7 @@ class IocProcessor:
             self.log.debug(f"not saved {ioc} because it is a sensor")
             return None
 
-        if ioc.type == IocType.DOMAIN and is_whatsmyip_domain(ioc.name):
+        if ioc.type == IocType.DOMAIN and ioc.name in self._whatsmyip_domains:
             self.log.debug(f"not saved {ioc} because it is a whats-my-ip domain")
             return None
 

--- a/greedybear/cronjobs/extraction/utils.py
+++ b/greedybear/cronjobs/extraction/utils.py
@@ -8,83 +8,7 @@ import requests
 from django.conf import settings
 
 from greedybear.consts import DOMAIN, IP
-from greedybear.models import IOC, FireHolList, MassScanner, WhatsMyIPDomain
-
-
-def is_whatsmyip_domain(domain: str) -> bool:
-    """
-    Check if a domain is a known "what's my IP" service.
-
-    Args:
-        domain: Domain name to check.
-
-    Returns:
-        True if the domain is in the WhatsMyIP list, False otherwise.
-    """
-    try:
-        WhatsMyIPDomain.objects.get(domain=domain)
-    except WhatsMyIPDomain.DoesNotExist:
-        return False
-    return True
-
-
-def correct_ip_reputation(ip: str, ip_reputation: str) -> str:
-    """
-    Correct IP reputation based on mass scanner database.
-    Overrides reputation to "mass scanner" if the IP is found in the MassScanners table.
-    This is necessary because we have seen "mass scanners" incorrectly flagged.
-
-    Args:
-        ip: IP address to check.
-        ip_reputation: Current reputation string.
-
-    Returns:
-        Corrected reputation string.
-    """
-    if not ip_reputation or ip_reputation == "known attacker":
-        try:
-            MassScanner.objects.get(ip_address=ip)
-        except MassScanner.DoesNotExist:
-            pass
-        else:
-            ip_reputation = "mass scanner"
-    return ip_reputation
-
-
-def get_firehol_categories(ip: str, extracted_ip) -> list[str]:
-    """
-    Get FireHol categories for an IP address.
-    Checks both exact IP matches (for .ipset files) and network range
-    membership (for .netset files with CIDR notation).
-
-    Args:
-        ip: IP address string.
-        extracted_ip: Parsed IP address object from ipaddress library.
-
-    Returns:
-        List of FireHol source categories.
-    """
-    firehol_categories = []
-
-    # First check for exact IP match (for .ipset files)
-    exact_matches = FireHolList.objects.filter(ip_address=ip).values_list("source", flat=True)
-    # Filter out empty strings (from default='')
-    firehol_categories.extend([source for source in exact_matches if source])
-
-    # Then check if IP is within any network ranges (for .netset files)
-    # Only query entries that contain '/' (CIDR notation)
-    network_entries = FireHolList.objects.filter(ip_address__contains="/")
-    for entry in network_entries:
-        try:
-            network_range = ip_network(entry.ip_address, strict=False)
-            # Check entry.source is not empty and not already in list
-            if extracted_ip in network_range and entry.source and entry.source not in firehol_categories:
-                firehol_categories.append(entry.source)
-        except (ValueError, IndexError):
-            # Not a valid network range, skip
-            continue
-
-    return firehol_categories
+from greedybear.models import IOC, FireHolList, MassScanner
 
 
 def iocs_from_hits(hits: list[dict]) -> list[IOC]:
@@ -95,6 +19,9 @@ def iocs_from_hits(hits: list[dict]) -> list[IOC]:
     Enriches IOCs with FireHol categories at creation time to ensure
     only fresh data is used.
 
+    Performs bulk database lookups before the main loop to avoid
+    N+1 query overhead when processing large batches.
+
     Args:
         hits: List of Elasticsearch hit dictionaries.
 
@@ -104,6 +31,33 @@ def iocs_from_hits(hits: list[dict]) -> list[IOC]:
     hits_by_ip = defaultdict(list)
     for hit in hits:
         hits_by_ip[hit["src_ip"]].append(hit)
+
+    all_ips = list(hits_by_ip.keys())
+
+    # --- Bulk prefetch: FireHol exact matches (for .ipset files) ---
+    firehol_exact = defaultdict(list)
+    for entry_ip, source in FireHolList.objects.filter(
+        ip_address__in=all_ips,
+    ).values_list("ip_address", "source"):
+        if source:
+            firehol_exact[entry_ip].append(source)
+
+    # --- Bulk prefetch: FireHol CIDR entries (for .netset files) ---
+    # Fetched once; the same set of network ranges applies to every IP.
+    cidr_entries = []
+    for entry in FireHolList.objects.filter(ip_address__contains="/"):
+        try:
+            cidr_entries.append((ip_network(entry.ip_address, strict=False), entry.source))
+        except (ValueError, IndexError):
+            continue
+
+    # --- Bulk prefetch: MassScanner IPs ---
+    mass_scanner_ips = set(
+        MassScanner.objects.filter(
+            ip_address__in=all_ips,
+        ).values_list("ip_address", flat=True)
+    )
+
     iocs = []
     for ip, hits in hits_by_ip.items():
         dest_ports = [hit["dest_port"] for hit in hits if "dest_port" in hit]
@@ -111,7 +65,11 @@ def iocs_from_hits(hits: list[dict]) -> list[IOC]:
         if extracted_ip.is_loopback or extracted_ip.is_private or extracted_ip.is_multicast or extracted_ip.is_link_local or extracted_ip.is_reserved:
             continue
 
-        firehol_categories = get_firehol_categories(ip, extracted_ip)
+        # Build FireHol categories from prefetched data
+        firehol_categories = list(firehol_exact.get(ip, []))
+        for network, source in cidr_entries:
+            if source and extracted_ip in network and source not in firehol_categories:
+                firehol_categories.append(source)
 
         # Collect unique sensors from hits, deduplicated by sensor ID
         sensors_map = {hit["_sensor"].id: hit["_sensor"] for hit in hits if hit.get("_sensor") is not None and getattr(hit["_sensor"], "id", None)}
@@ -119,11 +77,16 @@ def iocs_from_hits(hits: list[dict]) -> list[IOC]:
         # Sort sensors by ID for consistent processing order
         sensors.sort(key=lambda s: s.id)
 
+        # Correct IP reputation from prefetched MassScanner set
+        ip_rep = hits[0].get("ip_rep", "")
+        if (not ip_rep or ip_rep == "known attacker") and ip in mass_scanner_ips:
+            ip_rep = "mass scanner"
+
         ioc = IOC(
             name=ip,
             type=get_ioc_type(ip),
             interaction_count=len(hits),
-            ip_reputation=correct_ip_reputation(ip, hits[0].get("ip_rep", "")),
+            ip_reputation=ip_rep,
             asn=hits[0].get("geoip", {}).get("asn"),
             destination_ports=sorted(set(dest_ports)),
             login_attempts=len(hits) if hits[0].get("type", "") == "Heralding" else 0,

--- a/tests/test_extraction_utils.py
+++ b/tests/test_extraction_utils.py
@@ -2,16 +2,8 @@ from datetime import datetime
 from unittest.mock import Mock, patch
 
 from greedybear.consts import DOMAIN, IP
-from greedybear.cronjobs.extraction.utils import (
-    correct_ip_reputation,
-    get_ioc_type,
-    iocs_from_hits,
-    is_valid_cidr,
-    is_valid_ipv4,
-    is_whatsmyip_domain,
-    threatfox_submission,
-)
-from greedybear.models import FireHolList, MassScanner, WhatsMyIPDomain
+from greedybear.cronjobs.extraction.utils import get_ioc_type, iocs_from_hits, is_valid_cidr, is_valid_ipv4, threatfox_submission
+from greedybear.models import FireHolList, MassScanner
 
 from . import CustomTestCase, ExtractionTestCase
 
@@ -282,38 +274,6 @@ class TestIsValidCIDR(CustomTestCase):
             is_valid, cidr = is_valid_cidr(value)
             self.assertFalse(is_valid)
             self.assertIsNone(cidr)
-
-
-class TestIsWhatsmyipDomain(CustomTestCase):
-    def test_returns_true_for_known_domain(self):
-        WhatsMyIPDomain.objects.create(domain="some.domain.com")
-        result = is_whatsmyip_domain("some.domain.com")
-        self.assertTrue(result)
-
-    def test_returns_false_for_unknown_domain(self):
-        result = is_whatsmyip_domain("another.domain.com")
-        self.assertFalse(result)
-
-
-class TestCorrectIpReputationTestCase(CustomTestCase):
-    def test_returns_mass_scanner_when_in_database(self):
-        MassScanner.objects.create(ip_address="1.2.3.4")
-        result = correct_ip_reputation("1.2.3.4", "known attacker")
-        self.assertEqual(result, "mass scanner")
-
-    def test_returns_original_when_not_in_database(self):
-        result = correct_ip_reputation("1.2.3.4", "known attacker")
-        self.assertEqual(result, "known attacker")
-
-    def test_checks_mass_scanner_for_empty_reputation(self):
-        MassScanner.objects.create(ip_address="1.2.3.4")
-        result = correct_ip_reputation("1.2.3.4", "")
-        self.assertEqual(result, "mass scanner")
-
-    def test_preserves_other_reputations(self):
-        MassScanner.objects.create(ip_address="1.2.3.4")
-        result = correct_ip_reputation("1.2.3.4", "bot")
-        self.assertEqual(result, "bot")
 
 
 class IocsFromHitsTestCase(CustomTestCase):

--- a/tests/test_ioc_processor.py
+++ b/tests/test_ioc_processor.py
@@ -1,5 +1,5 @@
 from datetime import date, datetime
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 from greedybear.consts import PAYLOAD_REQUEST, SCANNER
 from greedybear.cronjobs.extraction.ioc_processor import IocProcessor
@@ -22,15 +22,13 @@ class TestAddIoc(ExtractionTestCase):
         self.assertIsNone(result)
         self.mock_ioc_repo.save.assert_not_called()
 
-    @patch("greedybear.cronjobs.extraction.ioc_processor.is_whatsmyip_domain")
-    def test_filters_whatsmyip_domains(self, mock_whatsmyip):
-        mock_whatsmyip.return_value = True
+    def test_filters_whatsmyip_domains(self):
+        self.processor._whatsmyip_domains = {"some.domain.com"}
         ioc = self._create_mock_ioc(name="some.domain.com", ioc_type=IocType.DOMAIN)
 
         result = self.processor.add_ioc(ioc, attack_type=SCANNER)
 
         self.assertIsNone(result)
-        mock_whatsmyip.assert_called_once_with("some.domain.com")
         self.mock_ioc_repo.save.assert_not_called()
 
     def test_creates_new_ioc_when_not_exists(self):
@@ -178,8 +176,8 @@ class TestAddIoc(ExtractionTestCase):
         self.assertEqual(len(result.days_seen), 2)
         self.assertTrue(result.payload_request)
 
-    @patch("greedybear.cronjobs.extraction.ioc_processor.is_whatsmyip_domain")
-    def test_only_checks_whatsmyip_for_domains(self, mock_whatsmyip):
+    def test_only_checks_whatsmyip_for_domains(self):
+        self.processor._whatsmyip_domains = {"some.domain.com"}
         self.mock_sensor_repo.cache = {}
         self.mock_ioc_repo.get_ioc_by_name.return_value = None
         ioc = self._create_mock_ioc(name="1.2.3.4", ioc_type=IocType.IP)
@@ -187,7 +185,6 @@ class TestAddIoc(ExtractionTestCase):
 
         result = self.processor.add_ioc(ioc, attack_type=SCANNER)
 
-        mock_whatsmyip.assert_not_called()
         self.assertIsNotNone(result)
 
 


### PR DESCRIPTION
# Description

Eliminates ~15,000+ per-run database queries (N+1 queries) in the IOC extraction pipeline by bulk-prefetching `FireHolList`, `MassScanner`, and `WhatsMyIPDomain` data. 

* Bulk-fetches FireHol exact matches and CIDR ranges ahead of the inner loop in [utils.py](file:///Users/manik/GreedyBear/tests/test_extraction_utils.py).
* Bulk-fetches MassScanner IPs into a single O(1) in-memory set.
* Preloads the WhatsMyIPDomain set directly in `IocProcessor.__init__` rather than doing per-domain querying in [add_ioc](file:///Users/manik/GreedyBear/greedybear/cronjobs/extraction/ioc_processor.py#29-81).

### Related issues

Closes #1008 

### Type of change

- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `perf: bulk-prefetch extraction data. Closes #XYZ`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.
