### PR TITLE
refactor: move dashboard chart lists to dashboardConfig constants

### DIFF
--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -8,36 +8,12 @@ import {
 } from "@certego/certego-ui";
 
 import {
-  FeedsSourcesChart,
-  FeedsDownloadsChart,
-  EnrichmentSourcesChart,
-  EnrichmentRequestsChart,
-  FeedsTypesChart,
-} from "./utils/charts";
-
+  feedsChartList,
+  feedsTypesChartList,
+  enrichmentChartList,
+} from "../../constants/dashboardConfig";
 import EnrichmentLookup from "./EnrichmentLookup";
 
-const feedsChartList = [
-  ["FeedsSourcesChart", "Feeds: Sources", FeedsSourcesChart],
-  ["FeedsDownloadsChart", "Feeds: Downloads", FeedsDownloadsChart],
-];
-
-const feedsTypesChartList = [
-  ["FeedsTypesChart", "Feeds: Types", FeedsTypesChart],
-];
-
-const enrichmentChartList = [
-  [
-    "EnrichmentSourcesChart",
-    "Enrichment Service: Sources",
-    EnrichmentSourcesChart,
-  ],
-  [
-    "EnrichmentRequestsChart",
-    "Enrichment Service: Requests",
-    EnrichmentRequestsChart,
-  ],
-];
 
 function Dashboard() {
   console.debug("Dashboard rendered!");

--- a/frontend/src/constants/dashboardConfig.js
+++ b/frontend/src/constants/dashboardConfig.js
@@ -1,0 +1,21 @@
+import {
+  FeedsSourcesChart,
+  FeedsDownloadsChart,
+  EnrichmentSourcesChart,
+  EnrichmentRequestsChart,
+  FeedsTypesChart,
+} from "../components/dashboard/utils/charts";
+
+export const feedsChartList = [
+  ["FeedsSourcesChart", "Feeds: Sources", FeedsSourcesChart],
+  ["FeedsDownloadsChart", "Feeds: Downloads", FeedsDownloadsChart],
+];
+
+export const feedsTypesChartList = [
+  ["FeedsTypesChart", "Feeds: Types", FeedsTypesChart],
+];
+
+export const enrichmentChartList = [
+  ["EnrichmentSourcesChart", "Enrichment Service: Sources", EnrichmentSourcesChart],
+  ["EnrichmentRequestsChart", "Enrichment Service: Requests", EnrichmentRequestsChart],
+];


### PR DESCRIPTION
## Changes
- Moved hardcoded chart lists (feedsChartList, feedsTypesChartList, 
  enrichmentChartList) from Dashboard.jsx to a separate constants file
- This is the first step towards a config-driven dashboard widget system

## Motivation
Currently dashboard widgets are hardcoded in the component itself. 
Moving them to a constants file makes it easier to manage and 
is the foundation for GSoC #5 Dashboard Modularization project.