### PR TITLE
fix: eliminate N+1 queries in IocRepository.add_honeypot_to_ioc(). Closes #1012

### DIFF
--- a/greedybear/cronjobs/repositories/ioc.py
+++ b/greedybear/cronjobs/repositories/ioc.py
@@ -18,7 +18,7 @@ class IocRepository:
     def __init__(self):
         """Initialize the repository and populate the honeypot cache from the database."""
         self.log = logging.getLogger(f"{__name__}.{self.__class__.__name__}")
-        self._honeypot_cache = {self._normalize_name(hp.name): hp.active for hp in GeneralHoneypot.objects.all()}
+        self._honeypot_cache = {self._normalize_name(hp.name): hp for hp in GeneralHoneypot.objects.all()}
 
     def _normalize_name(self, name: str) -> str:
         """Normalize honeypot names for consistent cache and DB usage."""
@@ -38,8 +38,9 @@ class IocRepository:
         honeypot_set = {hp.name for hp in ioc.general_honeypot.all()}
         if honeypot_name not in honeypot_set:
             self.log.debug(f"adding honeypot {honeypot_name} to IoC {ioc}")
-            honeypot = self.get_hp_by_name(honeypot_name)
-            ioc.general_honeypot.add(honeypot)
+            honeypot = self._honeypot_cache.get(self._normalize_name(honeypot_name)) or self.get_hp_by_name(honeypot_name)
+            if honeypot is not None:
+                ioc.general_honeypot.add(honeypot)
         return ioc
 
     def create_honeypot(self, honeypot_name: str) -> GeneralHoneypot:
@@ -69,7 +70,7 @@ class IocRepository:
             if honeypot is None:
                 raise e
 
-        self._honeypot_cache[normalized] = honeypot.active
+        self._honeypot_cache[normalized] = honeypot
         return honeypot
 
     def get_active_honeypots(self) -> list[GeneralHoneypot]:
@@ -92,7 +93,7 @@ class IocRepository:
             The matching IOC, or None if not found.
         """
         try:
-            return IOC.objects.get(name=name)
+            return IOC.objects.prefetch_related("general_honeypot").get(name=name)
         except IOC.DoesNotExist:
             return None
 
@@ -129,7 +130,8 @@ class IocRepository:
             True if the honeypot is enabled, False otherwise.
         """
         normalized = self._normalize_name(honeypot_name)
-        return self._honeypot_cache.get(normalized, False)
+        hp = self._honeypot_cache.get(normalized)
+        return hp.active if hp is not None else False
 
     def is_ready_for_extraction(self, honeypot_name: str) -> bool:
         """

--- a/tests/test_ioc_repository.py
+++ b/tests/test_ioc_repository.py
@@ -421,6 +421,47 @@ class TestIocRepository(CustomTestCase):
         self.assertEqual(updated1.recurrence_probability, 0.75)
         self.assertEqual(updated2.recurrence_probability, 0.85)
 
+    # --- Tests for N+1 fix: cache stores GeneralHoneypot objects ---
+
+    def test_honeypot_cache_stores_generalhoneypot_objects(self):
+        """_honeypot_cache must store GeneralHoneypot instances, not booleans."""
+        for key, value in self.repo._honeypot_cache.items():
+            self.assertIsInstance(
+                value,
+                GeneralHoneypot,
+                f"Cache value for '{key}' should be a GeneralHoneypot instance, got {type(value)}",
+            )
+
+    def test_get_ioc_by_name_prefetches_general_honeypot(self):
+        """Accessing general_honeypot on a repo-fetched IOC must not trigger extra DB queries."""
+        ioc = self.repo.get_ioc_by_name("140.246.171.141")
+        self.assertIsNotNone(ioc)
+        with self.assertNumQueries(0):
+            list(ioc.general_honeypot.all())
+
+    def test_add_honeypot_to_ioc_uses_cache_not_db(self):
+        """When honeypot is in cache and the IOC was fetched with prefetch, no extra queries are needed."""
+        # Set up: IOC already associated with Cowrie
+        ioc = IOC.objects.create(name="5.5.5.5", type="ip")
+        ioc.general_honeypot.add(self.cowrie_hp)
+
+        # Fetch via repository (includes prefetch_related)
+        ioc_fetched = self.repo.get_ioc_by_name("5.5.5.5")
+
+        # add_honeypot_to_ioc should read from prefetch cache (.all() = 0 queries)
+        # and skip the add entirely (already associated), producing zero DB queries
+        with self.assertNumQueries(0):
+            result = self.repo.add_honeypot_to_ioc("Cowrie", ioc_fetched)
+
+        self.assertIn(self.cowrie_hp, result.general_honeypot.all())
+
+    def test_create_honeypot_stores_object_in_cache(self):
+        """create_honeypot must store the GeneralHoneypot object in cache, not a boolean."""
+        hp = self.repo.create_honeypot("CacheTestPot")
+        cached = self.repo._honeypot_cache.get("cachetestpot")
+        self.assertIsInstance(cached, GeneralHoneypot)
+        self.assertEqual(cached.pk, hp.pk)
+
 
 class TestScoringIntegration(CustomTestCase):
     """Integration tests for scoring jobs using IocRepository."""


### PR DESCRIPTION
# Description

Every call to `IocProcessor.add_ioc()` ends with a call to `add_honeypot_to_ioc()`. This method had two separate DB round-trips that fired once per IOC processed, even though both could be resolved from data already available in memory.

**Problem 1: `ioc.general_honeypot.all()` fired a live query per IOC.**
`get_ioc_by_name()` fetched IOCs without `prefetch_related('general_honeypot')`, so `ioc.general_honeypot.all()` inside `add_honeypot_to_ioc()` always triggered a fresh `SELECT` against the M2M through-table. With 5,000 unique IPs in a single extraction chunk, that is 5,000 avoidable queries.

**Problem 2: `_honeypot_cache` stored booleans, not objects.**
The cache built in `__init__` stored only `hp.active` (a boolean). When `add_honeypot_to_ioc()` needed the actual `GeneralHoneypot` object to call `ioc.general_honeypot.add(honeypot)`, the cache could not help, so the code always fell back to `get_hp_by_name()` — another live query per new IOC.

**Fixes applied:**

1. `get_ioc_by_name()`: added `prefetch_related("general_honeypot")` so Django's prefetch cache absorbs the M2M read, bringing the cost to 0 extra queries per IOC.
2. `_honeypot_cache`: changed to store `GeneralHoneypot` objects instead of booleans. `add_honeypot_to_ioc()` now reads the object directly from the cache (with `get_hp_by_name()` as a fallback for safety). `is_enabled()` and `create_honeypot()` updated accordingly.

Together these eliminate up to ~5,000–10,000 queries per extraction chunk depending on the ratio of new vs. existing IOCs, this is independent of the fix in #1008 which targets the `iocs_from_hits()` phase.
Problem 2 alone guarantees ~5,000 fewer queries per extraction run. Problem 1 adds up to another ~5,000 in steady-state runs where most IOCs are already known

### Related issues

- Closes #1012
- Related: #1008 (independent, complementary fix for the `iocs_from_hits()` phase)

### Type of change

- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

No GUI changes.