### PR TITLE
fix: record statistics only after input validation in cowrie_session_…

### DIFF
--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -71,9 +71,6 @@ def cowrie_session_view(request):
     include_session_data = request.query_params.get("include_session_data", "false").lower() == "true"
 
     logger.info(f"Cowrie view requested by {request.user} for {observable}")
-    source_ip = str(request.META["REMOTE_ADDR"])
-    request_source = Statistics(source=source_ip, view=ViewType.COWRIE_SESSION_VIEW.value)
-    request_source.save()
 
     if not observable:
         return HttpResponseBadRequest("Missing required 'query' parameter")
@@ -91,6 +88,9 @@ def cowrie_session_view(request):
         sessions = CowrieSession.objects.filter(commands=commands, duration__gt=0).prefetch_related("source", "commands", "credentials")
     else:
         return HttpResponseBadRequest("Query must be a valid IP address or SHA-256 hash")
+
+    source_ip = str(request.META["REMOTE_ADDR"])
+    Statistics(source=source_ip, view=ViewType.COWRIE_SESSION_VIEW.value).save()
 
     if include_similar:
         commands = {s.commands for s in sessions if s.commands}


### PR DESCRIPTION
# Description
While going through cowrie_session_view.py I noticed that the Statistics record was being saved before any input validation  so every invalid request (missing   query param, bad format) was still getting counted in the dashboard stats.                                                                                   Moved the save to after the validation block so it only runs when the request is actually valid, consistent with how enrichment_view already handles it.
                       

fixes  #1014 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [ ] All the tests gave 0 errors.