### PR TITLE
feat: allow querying CowrieSession API by password. Closes #607

### DIFF
--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -89,6 +89,8 @@ def cowrie_session_view(request):
             raise Http404(f"No command sequences found with hash: {observable}") from exc
         sessions = CowrieSession.objects.filter(commands=commands, duration__gt=0).prefetch_related("source", "commands", "credentials")
     else:
+        if len(observable) > 256:  # max_length of Credential.password field
+            return HttpResponseBadRequest("Query exceeds maximum password length")
         sessions = CowrieSession.objects.filter(credentials__password=observable, duration__gt=0).prefetch_related("source", "commands", "credentials")
         if not sessions.exists():
             raise Http404(f"No information found for password: {observable}")

--- a/tests/api/views/test_cowrie_session_view.py
+++ b/tests/api/views/test_cowrie_session_view.py
@@ -245,3 +245,24 @@ class CowrieSessionViewTestCase(CustomTestCase):
         """Test that view returns 404 for password with no matching sessions."""
         response = self.client.get("/api/cowrie_session?query=nonexistentpassword123")
         self.assertEqual(response.status_code, 404)
+
+    def test_password_query_with_similar(self):
+        """Test password query including similar sessions."""
+        response = self.client.get("/api/cowrie_session?query=root&include_similar=true")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("query", response.data)
+        self.assertIn("commands", response.data)
+        self.assertIn("sources", response.data)
+
+    def test_password_query_with_session_data(self):
+        """Test password query including session data."""
+        response = self.client.get("/api/cowrie_session?query=root&include_session_data=true")
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("sessions", response.data)
+        self.assertEqual(response.data["sessions"][0]["source"], "140.246.171.141")
+        self.assertEqual(response.data["sessions"][0]["credentials"][0], "root | root")
+
+    def test_password_too_long(self):
+        """Test that passwords exceeding max length return 400."""
+        response = self.client.get(f"/api/cowrie_session?query={'a' * 257}")
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
# Description

Allow querying the CowrieSession API by password. If the query parameter is neither a valid IP address nor a SHA-256 hash, it is treated as a password and returns all sessions where that password was used. This approach follows the existing query parameter design.
 As a result of the fallthrough approach, previously invalid queries now return 404 instead of 400.

### Related issues

Closes #607
Depends on #668 (now merged)

### Type of change

- [x] New feature (non-breaking change which adds functionality).

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I  have checked if my changes affect user-facing behavior that is described in the docs. The docs appear to be auto-generated from the docstring in cowrie_session.py, which has been updated in this PR. Please let me know if a separate docs PR is required.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.