### PR TITLE
Added test for useAuthStore component:Closes #987

### DIFF
--- a/frontend/tests/stores/useAuthStore.test.jsx
+++ b/frontend/tests/stores/useAuthStore.test.jsx
@@ -2,14 +2,42 @@ import { describe, test, expect, vi, beforeEach } from "vitest";
 import axios from "axios";
 import useAuthStore from "../../src/stores/useAuthStore";
 import { AUTHENTICATION_STATUSES } from "../../src/constants";
+import {
+  CHECK_AUTHENTICATION_URI,
+  CHANGE_PASSWORD_URI,
+  LOGIN_URI,
+  LOGOUT_URI,
+  USERACCESS_URI,
+} from "../../src/constants/api";
+import { addToast } from "@certego/certego-ui";
 
 vi.mock("axios");
+vi.mock("@certego/certego-ui", () => ({
+  addToast: vi.fn(),
+}));
+
+const INITIAL_USER = {
+  full_name: "",
+  first_name: "",
+  last_name: "",
+  email: "",
+};
+
+const createDeferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+};
 
 describe("useAuthStore", () => {
-  // Reset store before every test
   beforeEach(() => {
     useAuthStore.setState({
-      user: { full_name: "", first_name: "", last_name: "", email: "" },
+      user: INITIAL_USER,
       isSuperuser: false,
       isAuthenticated: AUTHENTICATION_STATUSES.FALSE,
     });
@@ -17,18 +45,11 @@ describe("useAuthStore", () => {
     vi.clearAllMocks();
   });
 
-  //initial state test
-
   describe("Initial State", () => {
     test("initial state is correct", () => {
       const state = useAuthStore.getState();
 
-      expect(state.user).toEqual({
-        full_name: "",
-        first_name: "",
-        last_name: "",
-        email: "",
-      });
+      expect(state.user).toEqual(INITIAL_USER);
 
       expect(state.isSuperuser).toBe(false);
 
@@ -36,42 +57,89 @@ describe("useAuthStore", () => {
     });
   });
 
-  //login tests
-
   describe("loginUser", () => {
-    test("sets authentication FALSE on failure", async () => {
-      axios.post.mockRejectedValue(new Error("login failure"));
+    test("sets authentication PENDING while request is in flight", async () => {
+      const deferred = createDeferred();
+      axios.post.mockReturnValue(deferred.promise);
+
+      const { loginUser } = useAuthStore.getState().service;
+      const loginPromise = loginUser({ username: "test", password: "123" });
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(
+        AUTHENTICATION_STATUSES.PENDING,
+      );
+
+      deferred.resolve({ data: {} });
+      await expect(loginPromise).resolves.toEqual({ data: {} });
+    });
+
+    test("sets authentication FALSE and emits error toast on failure", async () => {
+      const err = { parsedMsg: "bad credentials" };
+      axios.post.mockRejectedValue(err);
 
       const { loginUser } = useAuthStore.getState().service;
 
       await expect(
         loginUser({ username: "test", password: "123" }),
-      ).rejects.toThrow();
+      ).rejects.toEqual(err);
 
       expect(useAuthStore.getState().isAuthenticated).toBe(
         AUTHENTICATION_STATUSES.FALSE,
       );
+
+      expect(addToast).toHaveBeenCalledWith(
+        "Login failed!",
+        "bad credentials",
+        "danger",
+        true,
+      );
     });
 
-    test("sets authentication TRUE on success", async () => {
+    test("sets authentication TRUE and emits success toast on success", async () => {
       axios.post.mockResolvedValue({ data: {} });
 
       const { loginUser } = useAuthStore.getState().service;
 
       await loginUser({ username: "test", password: "123" });
 
-      expect(axios.post).toHaveBeenCalled();
+      expect(axios.post).toHaveBeenCalledWith(
+        LOGIN_URI,
+        { username: "test", password: "123" },
+        {
+          certegoUIenableProgressBar: false,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
 
       expect(useAuthStore.getState().isAuthenticated).toBe(
         AUTHENTICATION_STATUSES.TRUE,
       );
+
+      expect(addToast).toHaveBeenCalledWith(
+        "You've been logged in!",
+        null,
+        "success",
+      );
     });
   });
 
-  //logout tests
-
   describe("logoutUser", () => {
-    test("clears user and auth state", async () => {
+    test("sets authentication PENDING while logout request is in flight", async () => {
+      const deferred = createDeferred();
+      axios.post.mockReturnValue(deferred.promise);
+
+      const { logoutUser } = useAuthStore.getState().service;
+      const logoutPromise = logoutUser();
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(
+        AUTHENTICATION_STATUSES.PENDING,
+      );
+
+      deferred.resolve({});
+      await logoutPromise;
+    });
+
+    test("clears user and auth state with info toast on success", async () => {
       axios.post.mockResolvedValue({});
 
       useAuthStore.setState({
@@ -95,16 +163,40 @@ describe("useAuthStore", () => {
 
       expect(state.isSuperuser).toBe(false);
 
-      expect(state.user).toEqual({
-        full_name: "",
-        first_name: "",
-        last_name: "",
-        email: "",
+      expect(state.user).toEqual(INITIAL_USER);
+
+      expect(axios.post).toHaveBeenCalledWith(LOGOUT_URI, null, {
+        certegoUIenableProgressBar: false,
       });
+
+      expect(addToast).toHaveBeenCalledWith("Logged out!", null, "info");
+    });
+
+    test("still clears state and emits info toast on failure", async () => {
+      axios.post.mockRejectedValue(new Error("network"));
+
+      useAuthStore.setState({
+        isAuthenticated: AUTHENTICATION_STATUSES.TRUE,
+        user: {
+          full_name: "Test",
+          first_name: "Test",
+          last_name: "User",
+          email: "test@test.com",
+        },
+        isSuperuser: true,
+      });
+
+      const { logoutUser } = useAuthStore.getState().service;
+
+      await expect(logoutUser()).resolves.toBeUndefined();
+
+      const state = useAuthStore.getState();
+      expect(state.isAuthenticated).toBe(AUTHENTICATION_STATUSES.FALSE);
+      expect(state.isSuperuser).toBe(false);
+      expect(state.user).toEqual(INITIAL_USER);
+      expect(addToast).toHaveBeenCalledWith("Logged out!", null, "info");
     });
   });
-
-  //fetch user access test
 
   describe("fetchUserAccess", () => {
     test("stores user data", async () => {
@@ -123,14 +215,33 @@ describe("useAuthStore", () => {
 
       await fetchUserAccess();
 
+      expect(axios.get).toHaveBeenCalledWith(USERACCESS_URI, {
+        certegoUIenableProgressBar: false,
+        headers: { "Content-Type": "application/json" },
+      });
+
       expect(useAuthStore.getState().user.email).toBe("user1@test.com");
+    });
+
+    test("emits error toast when user access fetch fails", async () => {
+      const err = { parsedMsg: "access fetch failed" };
+      axios.get.mockRejectedValue(err);
+
+      const { fetchUserAccess } = useAuthStore.getState().service;
+
+      await fetchUserAccess();
+
+      expect(addToast).toHaveBeenCalledWith(
+        "Error fetching user access information!",
+        "access fetch failed",
+        "danger",
+      );
+      expect(useAuthStore.getState().user).toEqual(INITIAL_USER);
     });
   });
 
-  //check Authentication test
-
   describe("checkAuthentication", () => {
-    test("sets auth TRUE", async () => {
+    test("sets auth TRUE and updates superuser", async () => {
       axios.get.mockResolvedValue({
         data: { is_superuser: true },
       });
@@ -145,19 +256,81 @@ describe("useAuthStore", () => {
 
       expect(useAuthStore.getState().isSuperuser).toBe(true);
     });
+
+    test("sets auth FALSE when auth check fails while currently authenticated", async () => {
+      useAuthStore.setState({
+        isAuthenticated: AUTHENTICATION_STATUSES.TRUE,
+      });
+      axios.get.mockRejectedValue(new Error("auth check failed"));
+
+      const { checkAuthentication } = useAuthStore.getState();
+
+      await checkAuthentication();
+
+      expect(axios.get).toHaveBeenCalledWith(CHECK_AUTHENTICATION_URI, {
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(useAuthStore.getState().isAuthenticated).toBe(
+        AUTHENTICATION_STATUSES.FALSE,
+      );
+    });
+
+    test("keeps auth FALSE when auth check fails while already unauthenticated", async () => {
+      useAuthStore.setState({
+        isAuthenticated: AUTHENTICATION_STATUSES.FALSE,
+      });
+      axios.get.mockRejectedValue(new Error("auth check failed"));
+
+      const { checkAuthentication } = useAuthStore.getState();
+
+      await checkAuthentication();
+
+      expect(useAuthStore.getState().isAuthenticated).toBe(
+        AUTHENTICATION_STATUSES.FALSE,
+      );
+    });
   });
 
-  //change password test
-
   describe("changePassword", () => {
-    test("resolves on success", async () => {
-      axios.post.mockResolvedValue({ data: {} });
+    test("resolves on success and emits success toast", async () => {
+      const response = { data: {} };
+      axios.post.mockResolvedValue(response);
 
       const { changePassword } = useAuthStore.getState().service;
 
-      await expect(
-        changePassword({ old: "a", new: "b" }),
-      ).resolves.toBeDefined();
+      await expect(changePassword({ old: "a", new: "b" })).resolves.toEqual(
+        response,
+      );
+
+      expect(axios.post).toHaveBeenCalledWith(
+        CHANGE_PASSWORD_URI,
+        { old: "a", new: "b" },
+        {
+          headers: { "Content-Type": "application/json" },
+          certegoUIenableProgressBar: false,
+        },
+      );
+      expect(addToast).toHaveBeenCalledWith(
+        "Password changed successfully!",
+        null,
+        "success",
+      );
+    });
+
+    test("rejects on failure and emits error toast", async () => {
+      const err = { parsedMsg: "old password incorrect" };
+      axios.post.mockRejectedValue(err);
+
+      const { changePassword } = useAuthStore.getState().service;
+
+      await expect(changePassword({ old: "a", new: "b" })).rejects.toEqual(err);
+
+      expect(addToast).toHaveBeenCalledWith(
+        "Failed to change password!",
+        "old password incorrect",
+        "danger",
+        true,
+      );
     });
   });
 });


### PR DESCRIPTION
# Description

This PR  adds unit tests for `useAuthStore`.
The tests cover the main authentication functions for initial states, login success/failure, logout, fetching user access, checking authentication status, and password change. These tests improve coverage of the authentication store and help prevent regressions in critical auth functionality.

### Related issues
#987 

### Type of change

- [] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [x] I have provided a screenshot of the result in the PR.
- [x] I have created new frontend tests for the new component or updated existing ones.
  
###Result of the test :
<img width="1278" height="681" alt="image" src="https://github.com/user-attachments/assets/06dd798f-907a-4acd-b913-12a0c140a0d2" />


Note: A new test file `useAuthStore.test.jsx` was added under `frontend/tests/stores` to organise store-level tests.

