### PR TITLE
fix: replace socket.inet_aton with ipaddress.ip_address to support IPv6 sources.

### DIFF
--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -1,7 +1,7 @@
 # This file is a part of GreedyBear https://github.com/honeynet/GreedyBear
 # See the file 'LICENSE' for copying permission.
+import ipaddress
 import logging
-import socket
 
 from certego_saas.apps.auth.backend import CookieTokenAuthentication
 from django.conf import settings
@@ -112,7 +112,7 @@ def cowrie_session_view(request):
 
     unique_commands = {s.commands for s in sessions if s.commands}
     response_data["commands"] = sorted("\n".join(cmd.commands) for cmd in unique_commands)
-    response_data["sources"] = sorted({s.source.name for s in sessions}, key=socket.inet_aton)
+    response_data["sources"] = sorted({s.source.name for s in sessions}, key=lambda ip: ipaddress.ip_address(ip))
     if include_credentials:
         response_data["credentials"] = sorted({str(c) for s in sessions for c in s.credentials.all()})
     if include_session_data:


### PR DESCRIPTION
## Description
`socket.inet_aton` only supports IPv4 and would raise an `OSError` for IPv6 addresses. Replacing it with `ipaddress.ip_address` is more correct and consistent with how the rest of the codebase handles IP addresses (e.g. `iocs_from_hits()` in `extraction/utils.py`).

## Related issues
Closes #1055

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
### Formalities
- [x] I have read and understood the rules about how to Contribute to this project
- [x] My branch is based on `develop`
- [x] The pull request is for the branch `develop`
- [x] I have reviewed and verified any LLM-generated code included in this PR.(No LLMs used)

### Docs and tests
- [x] Linter (`Ruff`) gave 0 errors
- [x] All the tests gave 0 errors (752 tests passed)