### PR TITLE
enh: Log feature importances after Random Forest training . Closes #1050

### DIFF
--- a/greedybear/cronjobs/scoring/random_forest.py
+++ b/greedybear/cronjobs/scoring/random_forest.py
@@ -52,6 +52,15 @@ class RFModel(MLModel):
 
         self.model = self.untrained_model.fit(x_train, y_train)
         self.log.info(f"finished training {self.name} - recall AUC: {self.recall_auc(x_test, y_test):.4f}")
+
+        feature_names = x_train.columns.tolist()
+
+        importances = self.model.feature_importances_
+
+        sorted_features = sorted(zip(feature_names, importances, strict=False), key=lambda pair: pair[1], reverse=True)
+        importance_lines = "\n".join(f"  {name}: {score:.4f}" for name, score in sorted_features)
+
+        self.log.info(f"Feature importances for {self.name}:\n{importance_lines}")
         self.save()
 
     @property

--- a/tests/test_rf_models.py
+++ b/tests/test_rf_models.py
@@ -272,3 +272,60 @@ class TestTrainModelsSaveOnFailure(CustomTestCase):
 
         # The critical assertion: save_training_data must be called despite the crash
         job.save_training_data.assert_called_once()
+
+
+class TestFeatureImportanceLogging(CustomTestCase):
+    """Test that RFModel logs feature importances after training."""
+
+    IMPORTANCE_SAMPLE_DATA = pd.DataFrame(
+        {
+            "interactions_on_eval_day": [0, 1, 2, 0, 3, 1, 0, 2, 1, 3],
+            "feature1": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+            "feature2": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+            "feature3": [122, 12, 0, 14, 87, 34, 56, 78, 90, 11],
+            "honeypots": [
+                "cowrie,dionaea",
+                "dionaea,glutton",
+                "cowrie",
+                "glutton",
+                "cowrie,dionaea,glutton",
+                "cowrie",
+                "dionaea",
+                "glutton",
+                "cowrie,dionaea",
+                "dionaea,glutton",
+            ],
+        }
+    )
+
+    class MockRFModel(RFModel, Classifier):
+        def __init__(self):
+            super().__init__("Mock RF Model", "mock_score")
+
+        @property
+        def features(self):
+            return FEATURES
+
+        @property
+        def untrained_model(self):
+            mock = Mock()
+            mock.feature_names_in_ = FEATURES
+            mock.feature_importances_ = np.array([0.5, 0.3, 0.15, 0.02, 0.02, 0.01])
+            mock.fit.return_value = mock
+
+            a = np.zeros((10, 2))
+            a[:, 1] = [0.9, 0.8, 0.3, 0.2, 0.1, 0.7, 0.6, 0.4, 0.5, 0.3]
+            mock.predict_proba.return_value = a
+
+            return mock
+
+    def test_feature_importances_logged(self):
+        model = self.MockRFModel()
+        model.log = Mock()
+        model.save = Mock()
+
+        model.train(self.IMPORTANCE_SAMPLE_DATA)
+
+        logged_messages = [call.args[0] for call in model.log.info.call_args_list]
+
+        self.assertTrue(any("Feature importances for" in msg for msg in logged_messages))


### PR DESCRIPTION
# Description

This PR adds feature importance logging using `feature_importances_`, which Random Forest models expose for free after `.fit()`.

- `random_forest.py`: after training, retrieve `feature_importances_`, map to column names, sort descending, and log
- `test_rf_models.py`: add `TestFeatureImportanceLogging` to verify the importance block appears in logs


Example Log:
  ```
  active_days_ratio: 0.1275
  std_days_between: 0.1253
  days_seen_count: 0.1157
  login_attempts_per_day: 0.1133
  days_since_first_seen: 0.1111
  days_since_last_seen: 0.1009
  login_attempts: 0.0993
  interaction_count: 0.0794
```

### Related issues
closes: #1050 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
