### PR TITLE
Fix training_data validation to prevent runtime errors. Closes #1087

### DIFF
--- a/greedybear/cronjobs/scoring/scoring_jobs.py
+++ b/greedybear/cronjobs/scoring/scoring_jobs.py
@@ -104,7 +104,19 @@ class TrainModels(Cronjob):
             self.save_training_data()
             return
 
-        if not isinstance(training_data[0]["feed_type"], list):
+        # Validate training data structure before accessing
+        if not isinstance(training_data, list) or len(training_data) == 0:
+            self.log.warning("training data has invalid format, skip training")
+            self.save_training_data()
+            return
+
+        first_entry = training_data[0]
+        if not isinstance(first_entry, dict) or "feed_type" not in first_entry:
+            self.log.warning("training data missing required fields, skip training")
+            self.save_training_data()
+            return
+
+        if not isinstance(first_entry["feed_type"], list):
             self.log.warning("training data outdated, skip training")
             self.save_training_data()
             return


### PR DESCRIPTION
# Description

This PR improves the validation of `training_data` in `scoring_jobs.py` to prevent runtime errors caused by malformed or outdated data.

Previously, the code assumed that `training_data` was always a non-empty list of dictionaries containing the `feed_type` key. This could lead to `IndexError`, `KeyError`, or `TypeError` when the assumption was not met.

This change introduces defensive checks to ensure:
- `training_data` is a list
- it is not empty
- elements are dictionaries
- required keys like `feed_type` exist

If validation fails, the training step is skipped and a warning is logged instead of raising an exception.

---

### Related issues

- Closes #1087 

---

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

---

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior described in the docs.
- [x] Linter (`Ruff`) gave 0 errors.
- [ ] I have added tests for the feature/bug I solved.
- [ ] All the tests gave 0 errors.

### GUI changes

- [ ] Not applicable