### PR TITLE
fix: handle None session_id in CowrieSession.__str__

### DIFF
--- a/greedybear/models.py
+++ b/greedybear/models.py
@@ -125,6 +125,8 @@ class CowrieSession(models.Model):
         ]
 
     def __str__(self):
+        if self.session_id is None:
+            return "CowrieSession (unsaved)"
         return f"Session {hex(self.session_id)[2:]} from {self.source.name}"
 
 


### PR DESCRIPTION
Fixes #1083

`hex(self.session_id)` crashes with `TypeError` when `session_id` is `None` (unsaved object). Added a None check to return a safe fallback instead.