### PR TITLE
fix: reject promise on error in requestPasswordReset

### DIFF
--- a/frontend/src/components/auth/api.js
+++ b/frontend/src/components/auth/api.js
@@ -51,7 +51,7 @@ export async function requestPasswordReset(body) {
     return resp;
   } catch (err) {
     addToast("Failed to send email!", err.parsedMsg, "danger", true);
-    return null;
+    return Promise.reject(err);
   }
 }
 


### PR DESCRIPTION
Fixes #1095

`requestPasswordReset` was returning `null` on error while every other function in `api.js` returns `Promise.reject(err)`. This caused the UI to treat failures as success, closing the popover before the user could retry.

Changed `return null` to `return Promise.reject(err)` to match the existing pattern.