### PR TITLE
fix(cronjobs): update missing autonomous system names from enrichment. Closes #1130

### DIFF
--- a/greedybear/cronjobs/repositories/autonomous_system.py
+++ b/greedybear/cronjobs/repositories/autonomous_system.py
@@ -25,9 +25,11 @@ class ASRepository:
             AutonomousSystem instance
         """
         if asn in self._cache:
-            return self._cache[asn]
-
-        as_obj, created = AutonomousSystem.objects.get_or_create(asn=asn, defaults={"name": name or ""})
+            as_obj = self._cache[asn]
+            created = False
+        else:
+            as_obj, created = AutonomousSystem.objects.get_or_create(asn=asn, defaults={"name": name or ""})
+            self._cache[asn] = as_obj
 
         if created:
             self.log.info(f"Created new AS {asn} with name '{name}'")
@@ -36,5 +38,4 @@ class ASRepository:
             as_obj.save(update_fields=["name"])
             self.log.info(f"Updated AS {asn} name to '{name}'")
 
-        self._cache[asn] = as_obj
         return as_obj

--- a/tests/test_as_repo.py
+++ b/tests/test_as_repo.py
@@ -45,6 +45,22 @@ class ASRepositoryTestCase(CustomTestCase):
         as_obj = self.repo.get_or_create(asn_number, "intelowl/@GB")
         self.assertEqual(as_obj.name, "intelowl/@GB")
 
+    def test_preloaded_asn_updates_missing_name(self):
+        """An ASN preloaded into the cache with an empty name should still be updated."""
+        asn_number = 64510
+        AutonomousSystem.objects.create(asn=asn_number, name="")
+
+        # Re-initialize the repo so the DB object is preloaded into the cache
+        self.repo = ASRepository()
+        self.assertIn(asn_number, self.repo._cache)
+
+        as_obj = self.repo.get_or_create(asn_number, "CacheUpdateTest")
+        self.assertEqual(as_obj.name, "CacheUpdateTest")
+
+        # Verify it was updated in the database
+        db_obj = AutonomousSystem.objects.get(asn=asn_number)
+        self.assertEqual(db_obj.name, "CacheUpdateTest")
+
     def test_logging_on_create_and_update(self):
         """Ensure the logger logs info messages when creating or updating ASNs."""
         asn_number = 64504


### PR DESCRIPTION
# Description

This PR ensures that `AutonomousSystem` records with missing names are correctly updated when new enrichment data becomes available during the extraction pipeline.

Previously, if an ASN was already preloaded into the `ASRepository` cache with an empty name, the `get_or_create` method would return the cached object immediately, bypassing any potential updates. This led to persistent empty ASN names in the database even when human-readable names were being successfully retrieved by downstream processors.

Key changes:
- **Refactored `ASRepository.get_or_create`**: The method now continues to the update logic even on a cache hit, ensuring that empty names are filled if valid data is provided.
- **Efficient Updates**: Leveraged Django's `update_fields=["name"]` to ensure only the `name` column is touched, minimizing database overhead.
- **New Unit Test**: Added `test_preloaded_asn_updates_missing_name` to `tests/test_as_repo.py` to verify that preloaded records are correctly updated in both the cache and the database.

### Related issues

Closes #1130

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `fix(cronjobs): update missing autonomous system names from enrichment data. Closes #1130 `
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.