### PR TITLE
fix: handle None session_id in CowrieSession.__str__

### DIFF
--- a/greedybear/models.py
+++ b/greedybear/models.py
@@ -169,7 +169,7 @@ class CowrieSession(models.Model):
         indexes = [
             models.Index(fields=["source"]),
         ]
-def __str__(self):
+    def __str__(self):
     if self.session_id is None:
         return "New Session (unsaved)"
     return f"Session {hex(self.session_id)[2:]} from {self.source.name}"


### PR DESCRIPTION
## Description
Closes #1083

Fixes a `TypeError` that occurred when visiting `/api/admin/greedybear/ioc/add/` in the Django admin panel.

## Bug
When Django admin renders the IOC add form, it calls `__str__` on related `CowrieSession` objects. Since `session_id` is the primary key and is `None` on unsaved objects, calling `hex(self.session_id)` raised:

```
TypeError: 'NoneType' object cannot be interpreted as an integer
Exception Location: /opt/deploy/greedybear/greedybear/models.py, line 161, in __str__
```

## Root Cause
`CowrieSession` has a `ForeignKey` to `IOC`. When Django renders the IOC add form, it calls `__str__()` on related `CowrieSession` objects. Since `session_id` is `None` on unsaved objects, `hex(self.session_id)` crashes.

## Fix
Added a `None` check for `session_id` in `CowrieSession.__str__()` before calling `hex()`:

```python
# Before
def __str__(self):
    return f"Session {hex(self.session_id)[2:]} from {self.source.name}"

# After
def __str__(self):
    if self.session_id is None:
        return "New Session (unsaved)"
    return f"Session {hex(self.session_id)[2:]} from {self.source.name}"
```

## Steps to Reproduce
1. Run GreedyBear locally
2. Go to `/api/admin/greedybear/ioc/add/`
3. You will see `TypeError: 'NoneType' object cannot be interpreted as an integer`

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
