### PR TITLE
Refactor: move reputation update loggin into IocRepository. Closes #1107

### DIFF
--- a/greedybear/cronjobs/mass_scanners.py
+++ b/greedybear/cronjobs/mass_scanners.py
@@ -82,15 +82,4 @@ class MassScannersCron(Cronjob):
                 scanner, created = self.mass_scanner_repo.get_or_create(ip_address, reason)
                 if created:
                     self.log.info(f"added new mass scanner {ip_address}")
-                    self._update_old_ioc(ip_address)
-
-    def _update_old_ioc(self, ip_address: str):
-        """
-        Update the IP reputation of an existing IOC to mark it as a mass scanner.
-
-        Args:
-            ip_address: IP address to update.
-        """
-        updated = self.ioc_repo.update_ioc_reputation(ip_address, IpReputation.MASS_SCANNER)
-        if updated:
-            self.log.debug(f"Updated IOC {ip_address} reputation to '{IpReputation.MASS_SCANNER}'")
+                    self.ioc_repo.update_ioc_reputation(ip_address, IpReputation.MASS_SCANNER)

--- a/greedybear/cronjobs/repositories/ioc.py
+++ b/greedybear/cronjobs/repositories/ioc.py
@@ -278,6 +278,7 @@ class IocRepository:
             ioc = IOC.objects.get(name=ip_address)
             ioc.ip_reputation = reputation
             ioc.save()
+            self.log.info(f"Updated IOC {ip_address} reputation to '{reputation}'")
             return True
         except IOC.DoesNotExist:
             return False

--- a/greedybear/cronjobs/tor_exit_nodes.py
+++ b/greedybear/cronjobs/tor_exit_nodes.py
@@ -41,16 +41,10 @@ class TorExitNodesCron(Cronjob):
                 tor_node, created = self.tor_repo.get_or_create(ip_address)
                 if created:
                     self.log.info(f"Added new Tor exit node {ip_address}")
-                    self._update_old_ioc(ip_address)
+                    self.ioc_repo.update_ioc_reputation(ip_address, IpReputation.TOR_EXIT_NODE)
 
             self.log.info("Completed download of Tor exit node list")
 
         except requests.RequestException as e:
             self.log.error(f"Failed to fetch Tor exit nodes: {e}")
             raise
-
-    def _update_old_ioc(self, ip_address: str):
-        """Update the IP reputation of an existing IOC to mark it as a Tor exit node."""
-        updated = self.ioc_repo.update_ioc_reputation(ip_address, IpReputation.TOR_EXIT_NODE)
-        if updated:
-            self.log.debug(f"Updated IOC {ip_address} reputation to '{IpReputation.TOR_EXIT_NODE}'")

--- a/tests/test_tor.py
+++ b/tests/test_tor.py
@@ -84,15 +84,3 @@ class TestTorExitNodesCron(CustomTestCase):
         # Act & Assert
         with self.assertRaises(requests.RequestException):
             self.cron.run()
-
-    @patch("greedybear.cronjobs.tor_exit_nodes.is_valid_ipv4")
-    def test_update_old_ioc(self, mock_is_valid):
-        """Test updating existing IOCs."""
-        # Arrange
-        self.mock_ioc_repo.update_ioc_reputation.return_value = True
-
-        # Act
-        self.cron._update_old_ioc("1.2.3.4")
-
-        # Assert
-        self.mock_ioc_repo.update_ioc_reputation.assert_called_once_with("1.2.3.4", IpReputation.TOR_EXIT_NODE)


### PR DESCRIPTION
# Description

Moved the reputation update logging from individual cronjob wrapper methods into `IocRepository.update_ioc_reputation()`, matching how `TagRepository` already logs inside its methods. This removes the duplicate `_update_old_ioc()` methods from `MassScannersCron` and `TorExitNodesCron` — the callers now just call the repository method directly.

`ReverseDNSCron` was already refactored to use `bulk_update_ioc_reputation()` in a previous PR, so only two wrapper methods remained.


### Related issues

Closes #1107

### Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue).
 - [ ] New feature (non-breaking change which adds functionality).
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
 - [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).


# Checklist

### Formalities

  - [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
  - [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
  - [x] My branch is based on `develop`.
  - [x] The pull request is for the branch `develop`.
  - [x] I have reviewed and verified any LLM-generated code included in this PR.


### Docs and tests

  - [x] I documented my code changes with docstrings and/or comments.
  - [ ] I have checked if my changes affect user-facing behavior that is described in the
  [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
  - [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed
  [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
  - [x] I have added tests for the feature/bug I solved.
  - [x] All the tests gave 0 errors.