### PR TITLE
test: add LSH clustering coverage for #975

### DIFF
--- a/tests/test_lsh.py
+++ b/tests/test_lsh.py
@@ -1,0 +1,98 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from greedybear.cronjobs.commands.lsh import LSHConnectedComponents, UnionFind
+
+
+class UnionFindTestCase(TestCase):
+    def test_find_representative_applies_path_compression(self):
+        u = UnionFind(4)
+        u.parents = [0, 0, 1, 2]
+
+        representative = u.find_representative(3)
+
+        self.assertEqual(representative, 0)
+        self.assertEqual(u.parents[3], 0)
+        self.assertEqual(u.parents[2], 0)
+
+    def test_union_merges_two_sets(self):
+        u = UnionFind(3)
+
+        u.union(0, 1)
+
+        self.assertEqual(u.find_representative(0), u.find_representative(1))
+        self.assertNotEqual(u.find_representative(0), u.find_representative(2))
+
+
+class LSHConnectedComponentsTestCase(TestCase):
+    def test_get_min_hashes_generates_matching_signatures(self):
+        lsh = LSHConnectedComponents(num_perm=64)
+        sequences = [
+            ["ls", "-la", "/tmp"],
+            ["ls", "-la", "/tmp"],
+            ["python", "-m", "http.server"],
+        ]
+
+        min_hashes = lsh._get_min_hashes(sequences)
+
+        self.assertEqual(len(min_hashes), len(sequences))
+        self.assertEqual(min_hashes[0].jaccard(min_hashes[1]), 1.0)
+        self.assertLess(min_hashes[0].jaccard(min_hashes[2]), 0.5)
+
+    def test_get_labels_maps_components_to_compact_labels(self):
+        sequences = [["a"], ["b"], ["c"], ["d"], ["e"]]
+        u = UnionFind(len(sequences))
+        u.union(0, 2)
+        u.union(2, 4)
+        u.union(1, 3)
+
+        labels = LSHConnectedComponents()._get_labels(sequences, u)
+
+        self.assertEqual(labels, [0, 1, 0, 1, 0])
+
+    def test_get_components_returns_empty_for_empty_input(self):
+        labels = LSHConnectedComponents().get_components([])
+        self.assertEqual(labels, [])
+
+    def test_get_components_groups_similar_sequences(self):
+        sequences = [
+            ["echo", "hello", "world"],
+            ["echo", "hello", "world"],
+            ["wget", "http://example.com"],
+            ["wget", "http://example.com"],
+        ]
+
+        labels = LSHConnectedComponents(threshold=0.8, num_perm=256).get_components(sequences)
+
+        self.assertEqual(len(labels), 4)
+        self.assertEqual(labels[0], labels[1])
+        self.assertEqual(labels[2], labels[3])
+        self.assertNotEqual(labels[0], labels[2])
+
+    def test_get_components_uses_lsh_matches_and_ignores_self_matches(self):
+        class FakeLSH:
+            def __init__(self, threshold, num_perm):
+                self.threshold = threshold
+                self.num_perm = num_perm
+                self._inserted = []
+
+            def insert(self, idx, min_hash):
+                self._inserted.append((idx, min_hash))
+
+            def query(self, min_hash):
+                if min_hash == "mh0":
+                    return [0, 1]
+                if min_hash == "mh1":
+                    return [1, 0, 2]
+                return [2, 1]
+
+        lsh = LSHConnectedComponents(threshold=0.7, num_perm=32)
+        sequences = [["a"], ["b"], ["c"]]
+
+        with (
+            patch.object(lsh, "_get_min_hashes", return_value=["mh0", "mh1", "mh2"]),
+            patch("greedybear.cronjobs.commands.lsh.MinHashLSH", FakeLSH),
+        ):
+            labels = lsh.get_components(sequences)
+
+        self.assertEqual(labels, [0, 0, 0])


### PR DESCRIPTION
# Description

This PR adds focused test coverage for the mathematical clustering logic in `greedybear/cronjobs/commands/lsh.py`.

Summary of changes:

- Added new tests in `tests/test_lsh.py`
- Covered:
  - Union-Find path compression and union behavior
  - MinHash signature generation
  - Label compaction from connected components
  - Empty-input behavior
  - Similar/dissimilar clustering behavior
  - Deterministic LSH query flow with self-match filtering
- Targeted coverage for `greedybear/cronjobs/commands/lsh.py` reached 100% in isolated run

### Related issues

- Closes #975

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [ ] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [ ] My branch is based on `develop`.
- [ ] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [ ] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [ ] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [ ] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.

# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
