### PR TITLE
All instances don't hit enrichment sources at the same time. Closes #1158

### DIFF
--- a/greedybear/cronjobs/schedules.py
+++ b/greedybear/cronjobs/schedules.py
@@ -90,13 +90,13 @@ def setup_schedules():
             "func": "greedybear.tasks.check_reverse_dns",
             "cron": "7 6 * * *",
         },
-        # 11. ThreatFox Enrichment: Weekly (Sunday) at 01:07
+        # 11. ThreatFox Enrichment: Weekly (Sunday) at deterministic time outside 00:00-02:00
         {
             "name": "enrich_threatfox",
             "func": "greedybear.tasks.enrich_threatfox",
             "cron": _external_weekly_cron("enrich_threatfox"),
         },
-        # 12. AbuseIPDB Enrichment: Weekly (Sunday) at 01:07
+        # 12. AbuseIPDB Enrichment: Weekly (Sunday) at deterministic time outside 00:00-02:00
         {
             "name": "enrich_abuseipdb",
             "func": "greedybear.tasks.enrich_abuseipdb",

--- a/greedybear/cronjobs/schedules.py
+++ b/greedybear/cronjobs/schedules.py
@@ -60,29 +60,29 @@ def setup_schedules():
             "func": "greedybear.tasks.clean_up_db",
             "cron": "7 1 * * *",
         },
-        # Mass Scanners: Weekly (Sunday) at 01:07
+        # Mass Scanners: Weekly (Sunday) at deterministic time outside 00:00-02:00
         {
             "name": "get_mass_scanners",
             "func": "greedybear.tasks.get_mass_scanners",
-            "cron": "7 1 * * 0",
+            "cron": _external_weekly_cron("get_mass_scanners"),
         },
-        # WhatsMyIP: Weekly (Sunday) at 01:07
+        # WhatsMyIP: Weekly (Sunday) at deterministic time outside 00:00-02:00
         {
             "name": "get_whatsmyip",
             "func": "greedybear.tasks.get_whatsmyip",
-            "cron": "7 1 * * 0",
+            "cron": _external_weekly_cron("get_whatsmyip"),
         },
-        # Firehol Lists: Weekly (Sunday) at 01:07
+        # Firehol Lists: Weekly (Sunday) at deterministic time outside 00:00-02:00
         {
             "name": "extract_firehol_lists",
             "func": "greedybear.tasks.extract_firehol_lists",
-            "cron": "7 1 * * 0",
+            "cron": _external_weekly_cron("extract_firehol_lists"),
         },
-        # Tor Exit Nodes: Weekly (Sunday) at 01:07
+        # Tor Exit Nodes: Weekly (Sunday) at deterministic time outside 00:00-02:00
         {
             "name": "get_tor_exit_nodes",
             "func": "greedybear.tasks.get_tor_exit_nodes",
-            "cron": "7 1 * * 0",
+            "cron": _external_weekly_cron("get_tor_exit_nodes"),
         },
         # 10. Reverse DNS Scanner Check: Daily at 06:07
         {

--- a/greedybear/cronjobs/schedules.py
+++ b/greedybear/cronjobs/schedules.py
@@ -1,5 +1,18 @@
+import hashlib
+
 from django.conf import settings
 from django_q.models import Schedule
+
+
+def _external_weekly_cron(job_name: str) -> str:
+    """Return a deterministic Sunday cron for external jobs outside 00:00-02:00."""
+    seed_value = f"{settings.SECRET_KEY}:{job_name}"
+    digest = hashlib.sha256(seed_value.encode()).digest()
+    seed_int = int.from_bytes(digest[:8], byteorder="big", signed=False)
+
+    minute = seed_int % 60
+    hour = 2 + ((seed_int // 60) % 22)
+    return f"{minute} {hour} * * 0"
 
 
 def setup_schedules():
@@ -81,13 +94,13 @@ def setup_schedules():
         {
             "name": "enrich_threatfox",
             "func": "greedybear.tasks.enrich_threatfox",
-            "cron": "7 1 * * 0",
+            "cron": _external_weekly_cron("enrich_threatfox"),
         },
         # 12. AbuseIPDB Enrichment: Weekly (Sunday) at 01:07
         {
             "name": "enrich_abuseipdb",
             "func": "greedybear.tasks.enrich_abuseipdb",
-            "cron": "7 1 * * 0",
+            "cron": _external_weekly_cron("enrich_abuseipdb"),
         },
     ]
 

--- a/tests/greedybear/management/test_setup_schedules.py
+++ b/tests/greedybear/management/test_setup_schedules.py
@@ -55,6 +55,42 @@ class TestSetupSchedules(TestCase):
         extract_call = next(c for c in calls if c[1]["name"] == "extract_all")
         self.assertEqual(extract_call[1]["defaults"]["cron"], "*/5 * * * *")
 
+    @patch("greedybear.cronjobs.schedules.Schedule")
+    @override_settings(EXTRACTION_INTERVAL=10, SECRET_KEY="test-secret")
+    def test_external_enrichment_cron_is_deterministic_and_outside_local_window(self, mock_schedule):
+        """External enrichment runs weekly on Sunday at deterministic times outside 00:00-02:00."""
+        mock_schedule.CRON = Schedule.CRON
+        mock_schedule.objects.update_or_create = MagicMock()
+        mock_schedule.objects.exclude = MagicMock(return_value=MagicMock())
+
+        call_command("setup_schedules")
+        first_calls = mock_schedule.objects.update_or_create.call_args_list
+
+        mock_schedule.objects.update_or_create.reset_mock()
+        call_command("setup_schedules")
+        second_calls = mock_schedule.objects.update_or_create.call_args_list
+
+        def get_cron(calls, name):
+            return next(c for c in calls if c[1]["name"] == name)[1]["defaults"]["cron"]
+
+        for job_name in ("enrich_threatfox", "enrich_abuseipdb"):
+            first_cron = get_cron(first_calls, job_name)
+            second_cron = get_cron(second_calls, job_name)
+
+            self.assertEqual(first_cron, second_cron)
+
+            minute_str, hour_str, day_of_month, month, day_of_week = first_cron.split()
+            hour = int(hour_str)
+            minute = int(minute_str)
+
+            self.assertGreaterEqual(hour, 2)
+            self.assertLessEqual(hour, 23)
+            self.assertGreaterEqual(minute, 0)
+            self.assertLessEqual(minute, 59)
+            self.assertEqual(day_of_month, "*")
+            self.assertEqual(month, "*")
+            self.assertEqual(day_of_week, "0")
+
     def test_orphan_schedules_are_deleted(self):
         """Test that orphaned schedules not in active_schedules list are deleted."""
         # Create an orphan schedule that's not in the active_schedules list

--- a/tests/greedybear/management/test_setup_schedules.py
+++ b/tests/greedybear/management/test_setup_schedules.py
@@ -57,8 +57,8 @@ class TestSetupSchedules(TestCase):
 
     @patch("greedybear.cronjobs.schedules.Schedule")
     @override_settings(EXTRACTION_INTERVAL=10, SECRET_KEY="test-secret")
-    def test_external_enrichment_cron_is_deterministic_and_outside_local_window(self, mock_schedule):
-        """External enrichment runs weekly on Sunday at deterministic times outside 00:00-02:00."""
+    def test_external_weekly_jobs_cron_are_deterministic_and_outside_local_window(self, mock_schedule):
+        """External weekly jobs run on Sunday at deterministic times outside 00:00-02:00."""
         mock_schedule.CRON = Schedule.CRON
         mock_schedule.objects.update_or_create = MagicMock()
         mock_schedule.objects.exclude = MagicMock(return_value=MagicMock())
@@ -73,7 +73,14 @@ class TestSetupSchedules(TestCase):
         def get_cron(calls, name):
             return next(c for c in calls if c[1]["name"] == name)[1]["defaults"]["cron"]
 
-        for job_name in ("enrich_threatfox", "enrich_abuseipdb"):
+        for job_name in (
+            "get_mass_scanners",
+            "get_whatsmyip",
+            "extract_firehol_lists",
+            "get_tor_exit_nodes",
+            "enrich_threatfox",
+            "enrich_abuseipdb",
+        ):
             first_cron = get_cron(first_calls, job_name)
             second_cron = get_cron(second_calls, job_name)
 


### PR DESCRIPTION
# Description

This PR fixes synchronized external enrichment scheduling across GreedyBear instances.

Previously, `enrich_threatfox` and `enrich_abuseipdb` both ran on a fixed Sunday time (`01:07`), so many deployments could hit third-party services simultaneously.

Now external enrichment jobs are scheduled at deterministic pseudo-random Sunday times derived from `SECRET_KEY + job_name`, constrained outside the local maintenance window (`00:00–02:00`). Local jobs remain unchanged.

### Related issues

- Closes #1158

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [ ] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.

# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
