### PR TITLE
fix qcluster permission error on mlmodels volume. Closes #1176

### DIFF
--- a/docker/default.yml
+++ b/docker/default.yml
@@ -71,6 +71,8 @@ services:
     container_name: greedybear_qcluster
     restart: unless-stopped
     stop_grace_period: 3m
+    entrypoint:
+      - ./docker/entrypoint_qcluster.sh
     command: sh -c "python manage.py setup_schedules && exec python manage.py qcluster"
     volumes:
       - generic_logs:/var/log/greedybear
@@ -82,7 +84,6 @@ services:
         condition: service_healthy
       app:
         condition: service_healthy
-    user: "www-data:www-data"
     healthcheck:
       disable: true
 

--- a/docker/entrypoint_qcluster.sh
+++ b/docker/entrypoint_qcluster.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Fix mlmodels ownership (volumes may retain files owned by a previous UID)
+chown -R www-data:www-data /opt/deploy/greedybear/mlmodels
+
+if [ "$DJANGO_TEST_SERVER" = "True" ]; then
+    # Dev mode: run as root (needed for hot-reload on volume-mounted source)
+    exec "$@"
+else
+    # Production mode: drop privileges to www-data before starting qcluster
+    exec gosu www-data "$@"
+fi


### PR DESCRIPTION
# Description

This PR fixes a `PermissionError` that occurs during `qcluster` model training after merging #1168.

Previously, `usermod -u 2000 www-data` mapped the `www-data` user to UID 2000 in the Docker container, and the `qcluster` service ran under this config. PR #1168 removed this mapping but kept the service running under the default `www-data` user (UID 33). Because Docker heavily persists the associated `mlmodels` volume data from prior executions, existing files remained owned by the stale UID 2000, denying the new `www-data` UID the ability to read or delete training data files and crashing model jobs.

Key changes:
- **New Entrypoint Script (`docker/entrypoint_qcluster.sh`)**: Added a targeted entrypoint for `qcluster` that explicitly runs `chown -R www-data:www-data` on the `/opt/deploy/greedybear/mlmodels` directory to ensure permissions align. Privileges are then securely dropped back to `www-data` via `gosu`, maintaining the established pattern used for `gunicorn`.
- **`docker-compose` Configuration Update**: Replaced `user: "www-data:www-data"` in `docker/default.yml` with the newly established `entrypoint_qcluster.sh` start sequence.

Before
<img width="637" height="125" alt="image" src="https://github.com/user-attachments/assets/51bbb451-f4ba-4ec7-a9ab-4452923eb0de" />

After
<img width="680" height="340" alt="image" src="https://github.com/user-attachments/assets/1979054b-02ad-48dc-91f3-c77cdda041e2" />

### Related issues

Closes #1176

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `fix qcluster permission error on mlmodels volume. Closes #1176`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved. 
- [x] All the tests gave 0 errors.