### PR TITLE
fix: scan all hits for GeoIP enrichment in iocs_from_hits(). Closes  #1174

### DIFF
--- a/greedybear/cronjobs/extraction/utils.py
+++ b/greedybear/cronjobs/extraction/utils.py
@@ -174,7 +174,7 @@ def iocs_from_hits(hits: list[dict]) -> list[IOC]:
         # Sort sensors by ID for consistent processing order
         sensors = sorted(sensors_map.values(), key=lambda s: s.id)
 
-        geoip = hits[0].get("geoip", {}) if hits else {}
+        geoip = next((h.get("geoip") for h in hits if h.get("geoip")), {})
         attacker_country = geoip.get("country_name", "")
 
         asn = geoip.get("asn")
@@ -185,7 +185,7 @@ def iocs_from_hits(hits: list[dict]) -> list[IOC]:
             name=ip,
             type=get_ioc_type(ip),
             interaction_count=len(hits),
-            ip_reputation=correct_ip_reputation(ip, hits[0].get("ip_rep", ""), mass_scanner_ips),
+            ip_reputation=correct_ip_reputation(ip, next((h.get("ip_rep", "") for h in hits if h.get("ip_rep")), ""), mass_scanner_ips),
             autonomous_system=autonomous_system,
             destination_ports=sorted(set(dest_ports)),
             login_attempts=login_attempts,

--- a/tests/test_extraction_utils.py
+++ b/tests/test_extraction_utils.py
@@ -413,6 +413,32 @@ class IocsFromHitsTestCase(CustomTestCase):
         ioc = iocs[0]
         self.assertIsNone(ioc.autonomous_system)
 
+    def test_geoip_from_later_hit_when_first_has_none(self):
+        """ASN and country must be taken from any geoip-enriched hit, not only hits[0]."""
+        hits = [
+            self._create_hit(src_ip="1.2.3.4"),
+            self._create_hit(src_ip="1.2.3.4", asn=13335),
+        ]
+        hits[1]["geoip"]["as_org"] = "CLOUDFLARE"
+        hits[1]["geoip"]["country_name"] = "United States"
+
+        iocs = iocs_from_hits(hits)
+        ioc = iocs[0]
+
+        self.assertIsNotNone(ioc.autonomous_system)
+        self.assertEqual(ioc.autonomous_system.asn, 13335)
+        self.assertEqual(ioc.attacker_country, "United States")
+
+    def test_ip_rep_from_later_hit_when_first_has_none(self):
+        """ip_rep should be read from first hit that carries it, not blindly hits[0]."""
+        hits = [
+            self._create_hit(src_ip="1.2.3.4", ip_rep=""),
+            self._create_hit(src_ip="1.2.3.4", ip_rep="known_attacker"),
+        ]
+        iocs = iocs_from_hits(hits)
+        ioc = iocs[0]
+        self.assertEqual(ioc.ip_reputation, "known_attacker")
+
     def test_extracts_timestamps(self):
         hits = [
             self._create_hit(src_ip="8.8.8.8", timestamp="2025-01-01T10:00:00.000Z"),


### PR DESCRIPTION
`iocs_from_hits()` was reading enrichment fields only from `hits[0]`.

For the same source IP, Elasticsearch hits in a batch may be mixed: the first hit can be unenriched while later hits contain valid `geoip` / `ip_rep` values. In this case, `autonomous_system`, `attacker_country`, and `ip_reputation` were silently degraded.

### What changed

- Replaced first-hit-only `geoip` lookup with first non-empty `geoip` lookup across the full hit list.
- Replaced first-hit-only `ip_rep` lookup with first non-empty `ip_rep` lookup across the full hit list.
- Added 2 regression tests:
  - `test_geoip_from_later_hit_when_first_has_none`
  - `test_ip_rep_from_later_hit_when_first_has_none`

### Related issues

Closes #1174

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [ ] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.