### PR TITLE
feat: expose IoC-Sensor relationship in authenticated API responses. Closes #781

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -237,6 +237,7 @@ class FeedsResponseSerializer(serializers.Serializer):
     attacker_country = serializers.CharField(allow_null=True, allow_blank=True, max_length=120)
     attacker_country_code = serializers.CharField(allow_null=True, allow_blank=True, max_length=2)
     tags = TagSerializer(many=True, required=False, default=list)
+    sensors = SensorSerializer(many=True, required=False, default=list)
 
     def validate_feed_type(self, feed_type):
         logger.debug(f"FeedsResponseSerializer - validation feed_type: '{feed_type}'")

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -153,13 +153,14 @@ def feeds_advanced(request):
         valid_feed_types,
         tag_key=request.query_params.get("tag_key", "").strip(),
         tag_value=request.query_params.get("tag_value", "").strip(),
+        include_sensors=True,
     )
     if paginate:
         paginator = CustomPageNumberPagination()
         iocs = paginator.paginate_queryset(iocs_queryset, request)
-        resp_data = feeds_response(request, iocs, feed_params, valid_feed_types, dict_only=True, verbose=verbose)
+        resp_data = feeds_response(request, iocs, feed_params, valid_feed_types, dict_only=True, verbose=verbose, include_sensors=True)
         return paginator.get_paginated_response(resp_data)
-    return feeds_response(request, iocs_queryset, feed_params, valid_feed_types, verbose=verbose)
+    return feeds_response(request, iocs_queryset, feed_params, valid_feed_types, verbose=verbose, include_sensors=True)
 
 
 @api_view(["GET"])

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -153,7 +153,9 @@ def get_valid_feed_types() -> frozenset[str]:
     return frozenset(feed_types)
 
 
-def get_queryset(request, feed_params, valid_feed_types, is_aggregated=False, serializer_class=FeedsRequestSerializer, tag_key="", tag_value="", include_sensors=False):
+def get_queryset(
+    request, feed_params, valid_feed_types, is_aggregated=False, serializer_class=FeedsRequestSerializer, tag_key="", tag_value="", include_sensors=False
+):
     """
     Build a queryset to filter IOC data based on the request parameters.
 
@@ -360,11 +362,7 @@ def feeds_response(request=None, iocs=None, feed_params=None, valid_feed_types=N
                 has_tags_annotation = "tags_json" in getattr(iocs, "query", type("", (), {"annotations": {}})()).annotations
                 has_sensors_annotation = include_sensors and "sensors_json" in getattr(iocs, "query", type("", (), {"annotations": {}})()).annotations
 
-            required_fields = tuple(
-                ("tags_json" if f == "tags" else f)
-                for f in required_fields
-                if f != "tags" or has_tags_annotation
-            )
+            required_fields = tuple(("tags_json" if f == "tags" else f) for f in required_fields if f != "tags" or has_tags_annotation)
             if has_sensors_annotation:
                 required_fields = required_fields + ("sensors_json",)
 

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -153,7 +153,7 @@ def get_valid_feed_types() -> frozenset[str]:
     return frozenset(feed_types)
 
 
-def get_queryset(request, feed_params, valid_feed_types, is_aggregated=False, serializer_class=FeedsRequestSerializer, tag_key="", tag_value=""):
+def get_queryset(request, feed_params, valid_feed_types, is_aggregated=False, serializer_class=FeedsRequestSerializer, tag_key="", tag_value="", include_sensors=False):
     """
     Build a queryset to filter IOC data based on the request parameters.
 
@@ -172,6 +172,8 @@ def get_queryset(request, feed_params, valid_feed_types, is_aggregated=False, se
             - Default: `FeedsRequestSerializer`.
         tag_key (str, optional): Filter IOCs by tag key. Only passed from feeds_advanced.
         tag_value (str, optional): Filter IOCs by tag value (case-insensitive substring). Only passed from feeds_advanced.
+        include_sensors (bool, optional): If True, annotates sensors_json for each IOC.
+            Only passed from authenticated views like feeds_advanced. Default: False.
 
     Returns:
         QuerySet: The filtered queryset of IOC data.
@@ -252,6 +254,15 @@ def get_queryset(request, feed_params, valid_feed_types, is_aggregated=False, se
                     distinct=True,
                 )
             )
+            if include_sensors:
+                iocs = iocs.annotate(
+                    sensors_json=ArrayAgg(
+                        JSONObject(address=F("sensors__address"), label=F("sensors__label")),
+                        filter=Q(sensors__isnull=False),
+                        default=Value([]),
+                        distinct=True,
+                    )
+                )
         iocs = iocs.order_by(feed_params.ordering)
         iocs = iocs[: int(feed_params.feed_size)]
 
@@ -276,7 +287,7 @@ def ioc_as_dict(ioc, fields: set) -> dict:
     return {k: v for k, v in ioc.__dict__.items() if k in fields}
 
 
-def feeds_response(request=None, iocs=None, feed_params=None, valid_feed_types=None, dict_only=False, verbose=False):
+def feeds_response(request=None, iocs=None, feed_params=None, valid_feed_types=None, dict_only=False, verbose=False, include_sensors=False):
     """
     Format the IOC data into the requested format (e.g., JSON, CSV, TXT).
 
@@ -339,13 +350,23 @@ def feeds_response(request=None, iocs=None, feed_params=None, valid_feed_types=N
             required_fields = base_fields + verbose_only_fields if verbose else base_fields
 
             # `tags_json` is annotated in get_queryset (only for JSON format) to avoid conflicting
-            # with the `tags` reverse FK on IOC.  When the queryset comes from a repository method
+            # with the `tags` reverse FK on IOC. When the queryset comes from a repository method
             # that does not annotate `tags_json` (e.g. the ML scoring path), exclude the field.
+            # `sensors_json` follows the same pattern and is only annotated for authenticated views.
             if isinstance(iocs, list):
                 has_tags_annotation = bool(iocs) and hasattr(iocs[0], "tags_json")
+                has_sensors_annotation = include_sensors and bool(iocs) and hasattr(iocs[0], "sensors_json")
             else:
                 has_tags_annotation = "tags_json" in getattr(iocs, "query", type("", (), {"annotations": {}})()).annotations
-            required_fields = tuple(("tags_json" if f == "tags" else f) for f in required_fields if f != "tags" or has_tags_annotation)
+                has_sensors_annotation = include_sensors and "sensors_json" in getattr(iocs, "query", type("", (), {"annotations": {}})()).annotations
+
+            required_fields = tuple(
+                ("tags_json" if f == "tags" else f)
+                for f in required_fields
+                if f != "tags" or has_tags_annotation
+            )
+            if has_sensors_annotation:
+                required_fields = required_fields + ("sensors_json",)
 
             iocs_iter: object
             if isinstance(iocs, list):
@@ -362,6 +383,7 @@ def feeds_response(request=None, iocs=None, feed_params=None, valid_feed_types=N
                     "destination_port_count": len(ioc.get("destination_ports", [])),
                     "asn": ioc.get("autonomous_system", ""),
                     "tags": ioc.pop("tags_json", []),
+                    **({"sensors": ioc.pop("sensors_json", [])} if has_sensors_annotation else {}),
                 }
 
                 if not verbose:

--- a/tests/api/views/test_enrichment_view.py
+++ b/tests/api/views/test_enrichment_view.py
@@ -90,6 +90,7 @@ class EnrichmentViewTestCase(CustomTestCase):
     def test_enrichment_includes_sensors(self):
         """Sensors field appears in enrichment response for authenticated users."""
         from greedybear.models import Sensor
+
         sensor = Sensor.objects.create(address="10.0.0.3", label="enrichment-sensor")
         self.ioc.sensors.add(sensor)
         response = self.client.get(f"/api/enrichment?query={self.ioc.name}")

--- a/tests/api/views/test_enrichment_view.py
+++ b/tests/api/views/test_enrichment_view.py
@@ -86,3 +86,16 @@ class EnrichmentViewTestCase(CustomTestCase):
         response = self.client.get("/api/enrichment?query=example.com")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["found"], False)
+
+    def test_enrichment_includes_sensors(self):
+        """Sensors field appears in enrichment response for authenticated users."""
+        from greedybear.models import Sensor
+        sensor = Sensor.objects.create(address="10.0.0.3", label="enrichment-sensor")
+        self.ioc.sensors.add(sensor)
+        response = self.client.get(f"/api/enrichment?query={self.ioc.name}")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["found"], True)
+        sensors = response.json()["ioc"]["sensors"]
+        self.assertEqual(len(sensors), 1)
+        self.assertEqual(sensors[0]["address"], "10.0.0.3")
+        self.assertEqual(sensors[0]["label"], "enrichment-sensor")

--- a/tests/api/views/test_enrichment_view.py
+++ b/tests/api/views/test_enrichment_view.py
@@ -1,5 +1,6 @@
 from rest_framework.test import APIClient
 
+from greedybear.models import Sensor
 from tests import CustomTestCase
 
 
@@ -89,7 +90,6 @@ class EnrichmentViewTestCase(CustomTestCase):
 
     def test_enrichment_includes_sensors(self):
         """Sensors field appears in enrichment response for authenticated users."""
-        from greedybear.models import Sensor
 
         sensor = Sensor.objects.create(address="10.0.0.3", label="enrichment-sensor")
         self.ioc.sensors.add(sensor)

--- a/tests/api/views/test_feeds_advanced_view.py
+++ b/tests/api/views/test_feeds_advanced_view.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from rest_framework.test import APIClient
 
 from api.throttles import SharedFeedRateThrottle
-from greedybear.models import IOC, AutonomousSystem, IocType, ShareToken
+from greedybear.models import IOC, AutonomousSystem, IocType, Sensor, ShareToken
 from tests import CustomTestCase
 
 
@@ -103,20 +103,45 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         self.assertIsNotNone(target_ioc)
         self.assertEqual(target_ioc["attacker_country"], "Nepal")
 
+
     def test_200_feed_contains_attacker_country_code(self):
         """
         Ensures that the response includes the attacker_country_code field.
         """
         self.ioc.attacker_country_code = "NP"
         self.ioc.save()
-
         response = self.client.get("/api/feeds/advanced/")
-
         iocs = response.json()["iocs"]
         target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
-
         self.assertIsNotNone(target_ioc)
         self.assertEqual(target_ioc["attacker_country_code"], "NP")
+
+    def test_feeds_advanced_includes_sensors(self):
+        """Sensors field appears in feeds_advanced response for authenticated users."""
+        sensor = Sensor.objects.create(address="10.0.0.1", label="test-sensor")
+        self.ioc.sensors.add(sensor)
+        response = self.client.get("/api/feeds/advanced/")
+        self.assertEqual(response.status_code, 200)
+        iocs = response.json()["iocs"]
+        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+        self.assertIsNotNone(target_ioc)
+        self.assertIn("sensors", target_ioc)
+        self.assertEqual(len(target_ioc["sensors"]), 1)
+        self.assertEqual(target_ioc["sensors"][0]["address"], "10.0.0.1")
+        self.assertEqual(target_ioc["sensors"][0]["label"], "test-sensor")
+
+    def test_public_feeds_excludes_sensors(self):
+        """Sensors field must NOT appear in public feeds response."""
+        sensor = Sensor.objects.create(address="10.0.0.2", label="secret-sensor")
+        self.ioc.sensors.add(sensor)
+        self.client.logout()
+        response = self.client.get(
+            "/api/feeds/cowrie/all/recent.json"
+        )
+        self.assertEqual(response.status_code, 200)
+        iocs = response.json()["iocs"]
+        for ioc in iocs:
+            self.assertNotIn("sensors", ioc)
 
 
 class FeedsEnhancementsTestCase(CustomTestCase):

--- a/tests/api/views/test_feeds_advanced_view.py
+++ b/tests/api/views/test_feeds_advanced_view.py
@@ -103,7 +103,6 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         self.assertIsNotNone(target_ioc)
         self.assertEqual(target_ioc["attacker_country"], "Nepal")
 
-
     def test_200_feed_contains_attacker_country_code(self):
         """
         Ensures that the response includes the attacker_country_code field.
@@ -135,9 +134,7 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         sensor = Sensor.objects.create(address="10.0.0.2", label="secret-sensor")
         self.ioc.sensors.add(sensor)
         self.client.logout()
-        response = self.client.get(
-            "/api/feeds/cowrie/all/recent.json"
-        )
+        response = self.client.get("/api/feeds/cowrie/all/recent.json")
         self.assertEqual(response.status_code, 200)
         iocs = response.json()["iocs"]
         for ioc in iocs:


### PR DESCRIPTION
# Description

The IoC model has a ManyToMany relationship with Sensor objects, but this relationship was not exposed in any API response. Previous attempts added sensors to IOCSerializer only, which does not affect the feeds API since it uses queryset.values(*base_fields) directly rather than the serializer.

This PR fixes that by mirroring the existing tags_json annotation pattern:
- sensors_json is annotated via ArrayAgg(JSONObject(address, label)) in get_queryset(), only for JSON format and only for authenticated views
- feeds_advanced passes include_sensors=True to both get_queryset() and feeds_response()
- All public endpoints (feeds, feeds_pagination, feeds_consume) get the default include_sensors=False, keeping sensor IPs completely absent
- Enrichment already worked via IOCSerializer and a dedicated test was added to prove the field actually appears in the API response

### Related issues

Closes #781

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about how to Contribute.
- [x] I chose an appropriate title for the pull request in the form: feat: expose IoC-Sensor relationship in authenticated API responses. Closes #781
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] No user-facing documentation changes required, this adds a new field to existing authenticated endpoints
- [x] Linter (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature (3 new tests: sensors in feeds_advanced, sensors absent from public feeds, sensors in enrichment)
- [x] All 839 tests gave 0 errors.