### PR TITLE
Fix include_similar returning invalid sessions (duration <= 0). Closes #1185

### DIFF
--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -101,7 +101,9 @@ def cowrie_session_view(request):
     if include_similar:
         commands = {s.commands for s in sessions if s.commands}
         clusters = {cmd.cluster for cmd in commands if cmd.cluster is not None}
-        related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters).prefetch_related("source", "commands", "credentials")
+        related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters, duration__gt=0).prefetch_related(
+            "source", "commands", "credentials"
+        )
         sessions = sessions.union(related_sessions)
 
     response_data = {

--- a/tests/api/views/test_cowrie_session_view.py
+++ b/tests/api/views/test_cowrie_session_view.py
@@ -272,6 +272,8 @@ class CowrieSessionViewTestCase(CustomTestCase):
             "/api/cowrie_session?query=140.246.171.141&include_similar=true&include_session_data=true"
         )
         self.assertEqual(response.status_code, 200)
+        self.assertIn("99.99.99.99", response.data["sources"])
+        self.assertTrue(any(s["source"] == "99.99.99.99" for s in response.data["sessions"]))
         self.assertNotIn("100.100.100.100", response.data["sources"])
         self.assertTrue(all(s["source"] != "100.100.100.100" for s in response.data["sessions"]))
 

--- a/tests/api/views/test_cowrie_session_view.py
+++ b/tests/api/views/test_cowrie_session_view.py
@@ -1,6 +1,7 @@
 from django.test import override_settings
 from rest_framework.test import APIClient
 
+from greedybear.models import CowrieSession
 from tests import CustomTestCase
 
 
@@ -253,6 +254,26 @@ class CowrieSessionViewTestCase(CustomTestCase):
         self.assertIn("query", response.data)
         self.assertIn("commands", response.data)
         self.assertIn("sources", response.data)
+
+    def test_include_similar_excludes_zero_duration_related_sessions(self):
+        """Regression: include_similar must not add related sessions with duration <= 0."""
+        CowrieSession.objects.create(
+            session_id=int("dddddddddddd", 16),
+            start_time=self.current_time,
+            duration=0,
+            login_attempt=True,
+            command_execution=True,
+            interaction_count=1,
+            source=self.ioc_3,
+            commands=self.command_sequence_2,
+        )
+
+        response = self.client.get(
+            "/api/cowrie_session?query=140.246.171.141&include_similar=true&include_session_data=true"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("100.100.100.100", response.data["sources"])
+        self.assertTrue(all(s["source"] != "100.100.100.100" for s in response.data["sessions"]))
 
     def test_password_query_with_session_data(self):
         """Test password query including session data."""


### PR DESCRIPTION
# Description

Fixed an issue where `include_similar=true` in the cowrie session API was ignoring the `duration__gt=0` filter. This was causing invalid/0-duration sessions to leak into the related clusters response, which contradicts how the base IP/hash/password queries work. 

I just tacked on the missing duration filter to the `related_sessions` queryset and added a regression test to make sure those 0-duration clustered sessions stay filtered out going forward.

### Related issues

Closes ##1185

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.