### PR TITLE
fix: use isinstance check instead of hasattr for _seen_honeypots

### DIFF
--- a/greedybear/cronjobs/extraction/utils.py
+++ b/greedybear/cronjobs/extraction/utils.py
@@ -288,7 +288,7 @@ def threatfox_submission(ioc_record: IOC, related_urls: list, log: Logger) -> No
     headers = {"Auth-Key": settings.THREATFOX_API_KEY}
     log.info(f"submitting IOC {urls_to_submit} to Threatfox")
 
-    if hasattr(ioc_record, "_seen_honeypots"):
+    if isinstance(getattr(ioc_record, "_seen_honeypots", None), list):
         seen_honeypots = ioc_record._seen_honeypots
     else:
         seen_honeypots = [hp.name for hp in ioc_record.general_honeypot.all()]

--- a/greedybear/cronjobs/repositories/ioc.py
+++ b/greedybear/cronjobs/repositories/ioc.py
@@ -37,7 +37,7 @@ class IocRepository:
         """
         normalized_name = self._normalize_name(honeypot_name)
 
-        if hasattr(ioc, "_seen_honeypots"):
+        if isinstance(getattr(ioc, "_seen_honeypots", None), list):
             honeypot_set = set(ioc._seen_honeypots)
         else:
             honeypot_set = {self._normalize_name(hp.name) for hp in ioc.general_honeypot.all()}


### PR DESCRIPTION
## Problem

When THREATFOX_API_KEY is set, test_get_url_downloads crashes with TypeError: can only join an iterable.

## Root Cause

A recent optimization PR replaced a database check with hasatr(ioc_record, '_seen_honeypots'). In tests, Mock objects always accept attribute access (hasattr returns True), so _seen_honeypots returns a Mock object instead of a list. This Mock then crashes .join().

## Fix

Replace hasattr(ioc, '_seen_honeypots') with isinstance(getattr(ioc, '_seen_honeypots', None), list) in both locations:

1. greedybear/cronjobs/extraction/utils.py:291
2. greedybear/cronjobs/repositories/ioc.py:40

This ensures the cached value is actually a list before using it, preventing both the test crash and potential runtime issues with unexpected attribute types.

Fixes #1201