### PR TITLE
Fix include_similar returning invalid sessions (duration <= 0) and ad…

### DIFF
--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -102,7 +102,7 @@ def cowrie_session_view(request):
         commands = {s.commands for s in sessions if s.commands}
         clusters = {cmd.cluster for cmd in commands if cmd.cluster is not None}
         related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters, duration__gt=0).prefetch_related("source", "commands", "credentials")
-        sessions = (sessions | related_sessions).distinct()
+        sessions = sessions.union(related_sessions)
 
     response_data = {
         "query": observable,

--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -104,7 +104,7 @@ def cowrie_session_view(request):
         related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters, duration__gt=0).prefetch_related(
             "source", "commands", "credentials"
         )
-        sessions = sessions.union(related_sessions)
+        sessions = (sessions | related_sessions).distinct()
 
     response_data = {
         "query": observable,

--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -101,7 +101,9 @@ def cowrie_session_view(request):
     if include_similar:
         commands = {s.commands for s in sessions if s.commands}
         clusters = {cmd.cluster for cmd in commands if cmd.cluster is not None}
-        related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters).prefetch_related("source", "commands", "credentials")
+        related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters, duration__gt=0).prefetch_related(
+            "source", "commands", "credentials"
+        )
         sessions = sessions.union(related_sessions)
 
     response_data = {

--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -101,9 +101,7 @@ def cowrie_session_view(request):
     if include_similar:
         commands = {s.commands for s in sessions if s.commands}
         clusters = {cmd.cluster for cmd in commands if cmd.cluster is not None}
-        related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters, duration__gt=0).prefetch_related(
-            "source", "commands", "credentials"
-        )
+        related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters, duration__gt=0).prefetch_related("source", "commands", "credentials")
         sessions = (sessions | related_sessions).distinct()
 
     response_data = {

--- a/tests/api/views/test_cowrie_session_view.py
+++ b/tests/api/views/test_cowrie_session_view.py
@@ -1,6 +1,7 @@
 from django.test import override_settings
 from rest_framework.test import APIClient
 
+from greedybear.models import CowrieSession
 from tests import CustomTestCase
 
 
@@ -33,6 +34,27 @@ class CowrieSessionViewTestCase(CustomTestCase):
         self.assertNotIn("credentials", response.data)
         self.assertNotIn("sessions", response.data)
         self.assertEqual(len(response.data["sources"]), 2)
+
+    def test_include_similar_excludes_non_positive_duration_sessions(self):
+        """Test that include_similar only returns sessions with duration > 0."""
+        CowrieSession.objects.create(
+            session_id=int("dddddddddddd", 16),
+            start_time=self.current_time,
+            duration=0,
+            login_attempt=True,
+            command_execution=True,
+            interaction_count=1,
+            source=self.ioc_3,
+            commands=self.command_sequence_2,
+        )
+
+        response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_similar=true&include_session_data=true")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("99.99.99.99", response.data["sources"])
+        self.assertNotIn("100.100.100.100", response.data["sources"])
+        self.assertTrue(any(session["duration"] > 0 for session in response.data["sessions"]))
+        self.assertFalse(any(session["source"] == "100.100.100.100" for session in response.data["sessions"]))
 
     def test_ip_address_query_with_credentials(self):
         """Test view with a valid IP address query including credentials."""


### PR DESCRIPTION
# Description

Hey everyone, this PR fixes the issue where `include_similar=true` was accidentally pulling in invalid sessions (duration <= 0). 

I just added the missing `duration__gt=0` filter to the `related_sessions` queryset so it matches the behavior of the main queries.

I also added a test for this. Taking the feedback from my previous attempt, the test now explicitly checks that valid related sessions are included, while the 0-duration ones are kept out.

Ran it locally and it passes:
```text
Found 1 test(s).
Creating test database for alias 'default'...
.
----------------------------------------------------------------------
Ran 1 test in 1.671s

OK
Destroying test database for alias 'default'...
```

### Related issues

Closes #1185

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.