### PR TITLE
fix: transition feeds_consume to allowlist for token revocation (#1190)

### DIFF
--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -258,8 +258,19 @@ def feeds_consume(request, token):
     """
     logger.info("request /api/feeds/consume with token")
     token_hash = hashlib.sha256(token.encode()).hexdigest()
-    if ShareToken.objects.filter(token_hash=token_hash, revoked=True).exists():
-        return Response({"error": "Token has been revoked"}, status=status.HTTP_400_BAD_REQUEST)
+    try:
+        share_token = ShareToken.objects.get(token_hash=token_hash)
+    except ShareToken.DoesNotExist:
+        return Response(
+            {"error": "Invalid or expired token"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if share_token.revoked:
+        return Response(
+            {"error": "Token has been revoked"},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
     try:
         data = signing.loads(token, salt="greedybear-feeds", max_age=86400 * 30)  # 30 days validity
     except signing.BadSignature:

--- a/tests/api/views/test_feeds_advanced_view.py
+++ b/tests/api/views/test_feeds_advanced_view.py
@@ -1,9 +1,14 @@
+import hashlib
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from django.conf import settings
+from django.core import signing
+from django.core.cache import cache
 from rest_framework.test import APIClient
 
-from greedybear.models import IOC, AutonomousSystem, IocType
+from api.throttles import SharedFeedRateThrottle
+from greedybear.models import IOC, AutonomousSystem, IocType, ShareToken
 from tests import CustomTestCase
 
 
@@ -246,8 +251,6 @@ class FeedsEnhancementsTestCase(CustomTestCase):
 
     def test_shareable_feed_expired_token(self):
         """Consuming a tampered/expired token returns 400."""
-        from django.core import signing
-
         data = {
             "feed_type": "all",
             "attack_type": "all",
@@ -276,10 +279,6 @@ class FeedsEnhancementsTestCase(CustomTestCase):
 
     def test_consume_valid_token_without_db_record_is_rejected(self):
         """A valid signed token that was never saved to the DB is rejected (allowlist check)."""
-        import hashlib
-
-        from django.core import signing
-
         data = {
             "feed_type": "all",
             "attack_type": "all",
@@ -302,8 +301,6 @@ class FeedsEnhancementsTestCase(CustomTestCase):
         token = signing.dumps(data, salt="greedybear-feeds")
         token_hash = hashlib.sha256(token.encode()).hexdigest()
 
-        from greedybear.models import ShareToken
-
         self.assertFalse(ShareToken.objects.filter(token_hash=token_hash).exists())
 
         self.client.logout()
@@ -313,10 +310,6 @@ class FeedsEnhancementsTestCase(CustomTestCase):
 
     def test_consume_token_deleted_from_db_is_rejected(self):
         """A token whose DB record has been deleted is rejected even though the signature is valid."""
-        import hashlib
-
-        from greedybear.models import ShareToken
-
         share_response = self.client.get("/api/feeds/share?asn=11111")
         self.assertEqual(share_response.status_code, 200)
         token = share_response.json()["url"].split("/")[-1]
@@ -339,12 +332,6 @@ class FeedsEnhancementsTestCase(CustomTestCase):
         then verifies the second request within the window returns 429.
         cache.clear() is scoped to this test to avoid leaking throttle state.
         """
-        from unittest.mock import patch
-
-        from django.core.cache import cache
-
-        from api.throttles import SharedFeedRateThrottle
-
         share_response = self.client.get("/api/feeds/share")
         token = share_response.json()["url"].split("/")[-1]
         anon = APIClient()

--- a/tests/api/views/test_feeds_advanced_view.py
+++ b/tests/api/views/test_feeds_advanced_view.py
@@ -274,6 +274,63 @@ class FeedsEnhancementsTestCase(CustomTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertIn("error", response.json())
 
+    def test_consume_valid_token_without_db_record_is_rejected(self):
+        """A valid signed token that was never saved to the DB is rejected (allowlist check)."""
+        import hashlib
+
+        from django.core import signing
+
+        data = {
+            "feed_type": "all",
+            "attack_type": "all",
+            "ioc_type": "all",
+            "max_age": "3",
+            "min_days_seen": "1",
+            "include_reputation": [],
+            "exclude_reputation": [],
+            "feed_size": "5000",
+            "ordering": "-last_seen",
+            "verbose": "false",
+            "paginate": "false",
+            "format": "json",
+            "asn": None,
+            "min_score": None,
+            "port": None,
+            "start_date": None,
+            "end_date": None,
+        }
+        token = signing.dumps(data, salt="greedybear-feeds")
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+
+        from greedybear.models import ShareToken
+
+        self.assertFalse(ShareToken.objects.filter(token_hash=token_hash).exists())
+
+        self.client.logout()
+        response = self.client.get(f"/api/feeds/consume/{token}")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "Invalid or expired token")
+
+    def test_consume_token_deleted_from_db_is_rejected(self):
+        """A token whose DB record has been deleted is rejected even though the signature is valid."""
+        import hashlib
+
+        from greedybear.models import ShareToken
+
+        share_response = self.client.get("/api/feeds/share?asn=11111")
+        self.assertEqual(share_response.status_code, 200)
+        token = share_response.json()["url"].split("/")[-1]
+
+        self.client.logout()
+        self.assertEqual(self.client.get(f"/api/feeds/consume/{token}").status_code, 200)
+
+        token_hash = hashlib.sha256(token.encode()).hexdigest()
+        ShareToken.objects.filter(token_hash=token_hash).delete()
+
+        response = self.client.get(f"/api/feeds/consume/{token}")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.json()["error"], "Invalid or expired token")
+
     def test_rate_limiting_consume(self):
         """
         Shared feed endpoint enforces rate limiting on the /feeds/consume/ endpoint.


### PR DESCRIPTION

# Description

Hey @regulartim,

I fixed the token revocation bypass issue as described in #1190.

The old check was only blocking tokens that had `revoked=True` in the database. If no `ShareToken` record existed at all (for example due to a failed DB write or a manually crafted token), the endpoint would still serve the feed.

I changed the logic to a proper allowlist check using `get()`:

```python
try:
    share_token = ShareToken.objects.get(token_hash=token_hash)
except ShareToken.DoesNotExist:
    return Response(
        {"error": "Invalid or expired token"},
        status=status.HTTP_400_BAD_REQUEST,
    )

if share_token.revoked:
    return Response(
        {"error": "Token has been revoked"},
        status=status.HTTP_400_BAD_REQUEST,
    )
```

I tested it exactly the same way I reported in the issue,  I created a valid signed token (using `signing.dumps` with the `greedybear-feeds` salt) but did **not** save it to the `ShareToken` table. Now it correctly returns `400 "Invalid or expired token"`.  
Normal revoked tokens and valid tokens continue to work as expected.

### Related issues
Closes #1190

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist
Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities
- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests
- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes
Ignore this section if you did not make any changes to the GUI.
- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.

Please let me know if any changes are required.