### PR TITLE
Cluster payload requests in command sequence clustering. Closes #523

### DIFF
--- a/greedybear/cronjobs/commands/cluster.py
+++ b/greedybear/cronjobs/commands/cluster.py
@@ -86,7 +86,7 @@ class ClusterCommandSequences(Cronjob):
         for seq in sequences:
             commands_for_clustering = list(seq.commands)
             for payload_url in sorted(payload_urls_by_sequence_id.get(seq.id, set())):
-                commands_for_clustering.append(f"PAYLOAD REQUEST {payload_url}")
+                commands_for_clustering.append(f"PAYLOAD_REQUEST:{payload_url}")
             tokenized_sequences.append(tokenize(commands_for_clustering))
 
         return tokenized_sequences

--- a/greedybear/cronjobs/commands/cluster.py
+++ b/greedybear/cronjobs/commands/cluster.py
@@ -66,12 +66,7 @@ class ClusterCommandSequences(Cronjob):
 
         payload_urls_by_sequence_id: dict[int, set[str]] = defaultdict(set)
         for scanner in scanners:
-            payload_urls = {
-                payload_url
-                for related_payload_ioc in scanner.related_ioc.all()
-                for payload_url in related_payload_ioc.related_urls
-                if payload_url
-            }
+            payload_urls = {payload_url for related_payload_ioc in scanner.related_ioc.all() for payload_url in related_payload_ioc.related_urls if payload_url}
             if not payload_urls:
                 continue
 

--- a/greedybear/cronjobs/commands/cluster.py
+++ b/greedybear/cronjobs/commands/cluster.py
@@ -1,6 +1,10 @@
+from collections import defaultdict
+
+from django.db.models import Prefetch
+
 from greedybear.cronjobs.base import Cronjob
 from greedybear.cronjobs.commands.lsh import LSHConnectedComponents
-from greedybear.models import CommandSequence
+from greedybear.models import IOC, CommandSequence, CowrieSession
 
 
 def tokenize(sequence: list[str]) -> list[str]:
@@ -29,26 +33,84 @@ class ClusterCommandSequences(Cronjob):
     A cronjob that clusters command sequences based on their similarity.
 
     This job processes all CommandSequence objects in the database, clusters them
-    using DBSCAN algorithm with Jaccard similarity as the distance metric, and
-    assigns cluster labels back to the objects. Commands within the same cluster
-    represent similar execution patterns.
+    with locality-sensitive hashing (LSH) connected components over tokenized
+    command sequences, and assigns cluster labels back to the objects. Commands
+    within the same cluster represent similar execution patterns.
     """
+
+    def _build_payload_urls_by_sequence_id(self, sequence_ids: list[int]) -> dict[int, set[str]]:
+        """
+        Build a mapping of command sequence IDs to payload URLs seen by related scanner IOCs.
+
+        The relation path is:
+        CommandSequence <- CowrieSession.source (scanner IOC) -> related_ioc (payload IOCs)
+        """
+        if not sequence_ids:
+            return {}
+
+        scanners = (
+            IOC.objects.filter(cowriesession__commands_id__in=sequence_ids)
+            .distinct()
+            .only("id")
+            .prefetch_related(
+                Prefetch(
+                    "related_ioc",
+                    queryset=IOC.objects.filter(payload_request=True).only("id", "related_urls"),
+                ),
+                Prefetch(
+                    "cowriesession_set",
+                    queryset=CowrieSession.objects.filter(commands_id__in=sequence_ids).only("commands_id"),
+                ),
+            )
+        )
+
+        payload_urls_by_sequence_id: dict[int, set[str]] = defaultdict(set)
+        for scanner in scanners:
+            payload_urls = {
+                payload_url
+                for related_payload_ioc in scanner.related_ioc.all()
+                for payload_url in related_payload_ioc.related_urls
+                if payload_url
+            }
+            if not payload_urls:
+                continue
+
+            for session in scanner.cowriesession_set.all():
+                if session.commands_id is not None:
+                    payload_urls_by_sequence_id[session.commands_id].update(payload_urls)
+
+        return payload_urls_by_sequence_id
+
+    def _build_clustering_input(self, sequences: list[CommandSequence]) -> list[list[str]]:
+        """
+        Prepare tokenized inputs for clustering by combining commands with payload observables.
+        """
+        payload_urls_by_sequence_id = self._build_payload_urls_by_sequence_id([seq.id for seq in sequences if seq.id is not None])
+
+        tokenized_sequences = []
+        for seq in sequences:
+            commands_for_clustering = list(seq.commands)
+            for payload_url in sorted(payload_urls_by_sequence_id.get(seq.id, set())):
+                commands_for_clustering.append(f"PAYLOAD REQUEST {payload_url}")
+            tokenized_sequences.append(tokenize(commands_for_clustering))
+
+        return tokenized_sequences
 
     def run(self) -> None:
         """
         Workflow:
         1. Retrieve all command sequences with their current cluster assignments
         2. Early exit if no sequences exist
-        3. Tokenize commands and performs DBSCAN clustering
+        3. Build tokenized clustering input and compute LSH connected components
         4. Identify sequences whose cluster assignment has changed
         5. Perform batched bulk updates for changed sequences only
         """
-        sequences = list(CommandSequence.objects.all().only("commands", "cluster"))
+        sequences = list(CommandSequence.objects.all().only("id", "commands", "cluster"))
         if not sequences:
             self.log.info("no sequences found to cluster")
             return
         self.log.info(f"clustering {len(sequences)} command sequences")
-        tokenized_seqs = [tokenize(s.commands) for s in sequences]
+        tokenized_seqs = self._build_clustering_input(sequences)
         cluster_labels = LSHConnectedComponents().get_components(tokenized_seqs)
         seqs_to_update = []
         for seq, label in zip(sequences, cluster_labels, strict=False):
@@ -57,4 +119,4 @@ class ClusterCommandSequences(Cronjob):
                 seqs_to_update.append(seq)
         self.log.info(f"writing updated clusters for {len(seqs_to_update)} command sequences to DB")
         result = CommandSequence.objects.bulk_update(seqs_to_update, ["cluster"], batch_size=1000) if seqs_to_update else 0
-        self.log.info(f"{result} IoCs were updated")
+        self.log.info(f"{result} command sequences were updated")

--- a/greedybear/cronjobs/commands/cluster.py
+++ b/greedybear/cronjobs/commands/cluster.py
@@ -49,7 +49,7 @@ class ClusterCommandSequences(Cronjob):
             return {}
 
         scanners = (
-            IOC.objects.filter(cowriesession__commands_id__in=sequence_ids)
+            IOC.objects.filter(cowriesession__commands_id__in=sequence_ids, scanner=True)
             .distinct()
             .only("id")
             .prefetch_related(

--- a/greedybear/cronjobs/commands/cluster.py
+++ b/greedybear/cronjobs/commands/cluster.py
@@ -100,7 +100,7 @@ class ClusterCommandSequences(Cronjob):
         4. Identify sequences whose cluster assignment has changed
         5. Perform batched bulk updates for changed sequences only
         """
-        sequences = list(CommandSequence.objects.all().only("id", "commands", "cluster"))
+        sequences = list(CommandSequence.objects.order_by("id").only("id", "commands", "cluster"))
         if not sequences:
             self.log.info("no sequences found to cluster")
             return

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -241,3 +241,234 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
         self.assertEqual(clustering_input, [tokenize(command_lines)])
         command_sequence.refresh_from_db()
         self.assertEqual(command_sequence.cluster, 77)
+
+    def test_run_ignores_scanner_payload_ioc_with_empty_related_urls(self):
+        """
+        Scanner-linked payload IOCs without related URLs do not affect clustering input.
+        """
+        CowrieSession.objects.all().delete()
+        CommandSequence.objects.all().delete()
+
+        command_lines = ["whoami"]
+        command_sequence = CommandSequence.objects.create(
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            commands=command_lines,
+            commands_hash=sha256("\n".join(command_lines).encode()).hexdigest(),
+            cluster=1,
+        )
+        scanner_ioc = IOC.objects.create(
+            name="198.51.100.50",
+            type=IocType.IP.value,
+            scanner=True,
+        )
+        payload_ioc = IOC.objects.create(
+            name="payload-empty.example",
+            type=IocType.DOMAIN.value,
+            payload_request=True,
+            related_urls=[],
+        )
+        scanner_ioc.related_ioc.add(payload_ioc)
+        CowrieSession.objects.create(
+            session_id=int("111111111111", 16),
+            start_time=self.current_time,
+            duration=1.0,
+            source=scanner_ioc,
+            commands=command_sequence,
+        )
+
+        with patch("greedybear.cronjobs.commands.cluster.LSHConnectedComponents") as mock_lsh_cls:
+            mock_lsh_cls.return_value.get_components.return_value = [12]
+            ClusterCommandSequences().run()
+            clustering_input = mock_lsh_cls.return_value.get_components.call_args[0][0]
+
+        self.assertEqual(clustering_input, [tokenize(command_lines)])
+        command_sequence.refresh_from_db()
+        self.assertEqual(command_sequence.cluster, 12)
+
+    def test_run_orders_multiple_payload_iocs_deterministically(self):
+        """
+        Payload URL observables from multiple related IOCs are deterministically sorted.
+        """
+        CowrieSession.objects.all().delete()
+        CommandSequence.objects.all().delete()
+
+        command_lines = ["echo start"]
+        command_sequence = CommandSequence.objects.create(
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            commands=command_lines,
+            commands_hash=sha256("\n".join(command_lines).encode()).hexdigest(),
+            cluster=2,
+        )
+        scanner_ioc = IOC.objects.create(
+            name="203.0.113.42",
+            type=IocType.IP.value,
+            scanner=True,
+        )
+        payload_ioc_1 = IOC.objects.create(
+            name="payload-1.example",
+            type=IocType.DOMAIN.value,
+            payload_request=True,
+            related_urls=["http://z.example/p.sh", "http://a.example/p.sh"],
+        )
+        payload_ioc_2 = IOC.objects.create(
+            name="payload-2.example",
+            type=IocType.DOMAIN.value,
+            payload_request=True,
+            related_urls=["http://m.example/p.sh"],
+        )
+        scanner_ioc.related_ioc.add(payload_ioc_2, payload_ioc_1)
+        CowrieSession.objects.create(
+            session_id=int("222222222222", 16),
+            start_time=self.current_time,
+            duration=1.0,
+            source=scanner_ioc,
+            commands=command_sequence,
+        )
+
+        with patch("greedybear.cronjobs.commands.cluster.LSHConnectedComponents") as mock_lsh_cls:
+            mock_lsh_cls.return_value.get_components.return_value = [34]
+            ClusterCommandSequences().run()
+            clustering_input = mock_lsh_cls.return_value.get_components.call_args[0][0]
+
+        expected_tokenized = tokenize(
+            command_lines
+            + [
+                "PAYLOAD REQUEST http://a.example/p.sh",
+                "PAYLOAD REQUEST http://m.example/p.sh",
+                "PAYLOAD REQUEST http://z.example/p.sh",
+            ]
+        )
+        self.assertEqual(clustering_input, [expected_tokenized])
+        command_sequence.refresh_from_db()
+        self.assertEqual(command_sequence.cluster, 34)
+
+    def test_run_shared_payload_url_across_sequences_can_yield_identical_labels(self):
+        """
+        Shared payload URL observables are present for both sequences and can drive identical labels.
+        """
+        CowrieSession.objects.all().delete()
+        CommandSequence.objects.all().delete()
+
+        first_sequence = CommandSequence.objects.create(
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            commands=["uname -a"],
+            commands_hash=sha256("uname -a".encode()).hexdigest(),
+            cluster=1001,
+        )
+        second_sequence = CommandSequence.objects.create(
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            commands=["id -u"],
+            commands_hash=sha256("id -u".encode()).hexdigest(),
+            cluster=1002,
+        )
+
+        shared_payload = IOC.objects.create(
+            name="shared-payload.example",
+            type=IocType.DOMAIN.value,
+            payload_request=True,
+            related_urls=["http://shared.example/payload.sh"],
+        )
+
+        first_scanner = IOC.objects.create(name="10.0.0.11", type=IocType.IP.value, scanner=True)
+        second_scanner = IOC.objects.create(name="10.0.0.12", type=IocType.IP.value, scanner=True)
+        first_scanner.related_ioc.add(shared_payload)
+        second_scanner.related_ioc.add(shared_payload)
+
+        CowrieSession.objects.create(
+            session_id=int("333333333333", 16),
+            start_time=self.current_time,
+            duration=1.0,
+            source=first_scanner,
+            commands=first_sequence,
+        )
+        CowrieSession.objects.create(
+            session_id=int("444444444444", 16),
+            start_time=self.current_time,
+            duration=1.0,
+            source=second_scanner,
+            commands=second_sequence,
+        )
+
+        def labels_from_payload_urls(tokenized_sequences):
+            payload_signature_to_label = {}
+            labels = []
+            for tokens in tokenized_sequences:
+                payload_urls = tuple(
+                    sorted(
+                        tokens[index + 2]
+                        for index in range(len(tokens) - 2)
+                        if tokens[index] == "PAYLOAD" and tokens[index + 1] == "REQUEST"
+                    )
+                )
+                label = payload_signature_to_label.setdefault(payload_urls, len(payload_signature_to_label) + 700)
+                labels.append(label)
+            return labels
+
+        with patch("greedybear.cronjobs.commands.cluster.LSHConnectedComponents") as mock_lsh_cls:
+            mock_lsh_cls.return_value.get_components.side_effect = labels_from_payload_urls
+            ClusterCommandSequences().run()
+
+        first_sequence.refresh_from_db()
+        second_sequence.refresh_from_db()
+        self.assertEqual(first_sequence.cluster, second_sequence.cluster)
+
+    def test_run_deduplicates_and_filters_empty_payload_urls(self):
+        """
+        Duplicate and empty payload URLs from related payload IOCs are normalized before clustering.
+        """
+        CowrieSession.objects.all().delete()
+        CommandSequence.objects.all().delete()
+
+        command_lines = ["pwd"]
+        command_sequence = CommandSequence.objects.create(
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            commands=command_lines,
+            commands_hash=sha256("\n".join(command_lines).encode()).hexdigest(),
+            cluster=9,
+        )
+        scanner_ioc = IOC.objects.create(
+            name="198.51.100.60",
+            type=IocType.IP.value,
+            scanner=True,
+        )
+        payload_ioc_1 = IOC.objects.create(
+            name="payload-dedup-1.example",
+            type=IocType.DOMAIN.value,
+            payload_request=True,
+            related_urls=["http://dup.example/a.sh", "", "http://dup.example/a.sh"],
+        )
+        payload_ioc_2 = IOC.objects.create(
+            name="payload-dedup-2.example",
+            type=IocType.DOMAIN.value,
+            payload_request=True,
+            related_urls=["http://dup.example/a.sh", "http://dup.example/b.sh"],
+        )
+        scanner_ioc.related_ioc.add(payload_ioc_1, payload_ioc_2)
+        CowrieSession.objects.create(
+            session_id=int("555555555555", 16),
+            start_time=self.current_time,
+            duration=1.0,
+            source=scanner_ioc,
+            commands=command_sequence,
+        )
+
+        with patch("greedybear.cronjobs.commands.cluster.LSHConnectedComponents") as mock_lsh_cls:
+            mock_lsh_cls.return_value.get_components.return_value = [99]
+            ClusterCommandSequences().run()
+            clustering_input = mock_lsh_cls.return_value.get_components.call_args[0][0]
+
+        expected_tokenized = tokenize(
+            command_lines
+            + [
+                "PAYLOAD REQUEST http://dup.example/a.sh",
+                "PAYLOAD REQUEST http://dup.example/b.sh",
+            ]
+        )
+        self.assertEqual(clustering_input, [expected_tokenized])
+        command_sequence.refresh_from_db()
+        self.assertEqual(command_sequence.cluster, 99)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -106,7 +106,7 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
 
     def test_run_no_label_changes(self):
         """seqs_to_update stays empty → bulk_update skipped (line 59 else branch)."""
-        seqs = list(CommandSequence.objects.all())
+        seqs = list(CommandSequence.objects.order_by("id"))
         current_labels = [s.cluster for s in seqs]
         self._run_job(current_labels)
         for seq, original_label in zip(seqs, current_labels, strict=False):
@@ -131,7 +131,7 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
 
     def test_run_all_labels_changed(self):
         """All sequences are updated when every label differs (lines 53–59)."""
-        seqs = list(CommandSequence.objects.all())
+        seqs = list(CommandSequence.objects.order_by("id"))
         new_labels = [777] * len(seqs)
         self._run_job(new_labels)
         for seq in seqs:
@@ -140,7 +140,7 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
 
     def test_run_bulk_update_called_with_correct_args(self):
         """bulk_update is called with field='cluster' and batch_size=1000 (line 59)."""
-        seqs = list(CommandSequence.objects.all())
+        seqs = list(CommandSequence.objects.order_by("id"))
         new_labels = [888] * len(seqs)
         with patch("greedybear.cronjobs.commands.cluster.LSHConnectedComponents") as mock_lsh_cls:
             mock_lsh_cls.return_value.get_components.return_value = new_labels

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -192,7 +192,7 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
 
             clustering_input = mock_lsh_cls.return_value.get_components.call_args[0][0]
 
-        expected_tokenized = tokenize(command_lines + ["PAYLOAD REQUEST http://payload.example.com/a.sh"])
+        expected_tokenized = tokenize(command_lines + ["PAYLOAD_REQUEST:http://payload.example.com/a.sh"])
         self.assertEqual(clustering_input, [expected_tokenized])
         command_sequence.refresh_from_db()
         self.assertEqual(command_sequence.cluster, 42)
@@ -335,9 +335,9 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
         expected_tokenized = tokenize(
             command_lines
             + [
-                "PAYLOAD REQUEST http://a.example/p.sh",
-                "PAYLOAD REQUEST http://m.example/p.sh",
-                "PAYLOAD REQUEST http://z.example/p.sh",
+                "PAYLOAD_REQUEST:http://a.example/p.sh",
+                "PAYLOAD_REQUEST:http://m.example/p.sh",
+                "PAYLOAD_REQUEST:http://z.example/p.sh",
             ]
         )
         self.assertEqual(clustering_input, [expected_tokenized])
@@ -355,14 +355,14 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
             first_seen=self.current_time,
             last_seen=self.current_time,
             commands=["uname -a"],
-            commands_hash=sha256("uname -a".encode()).hexdigest(),
+            commands_hash=sha256(b"uname -a").hexdigest(),
             cluster=1001,
         )
         second_sequence = CommandSequence.objects.create(
             first_seen=self.current_time,
             last_seen=self.current_time,
             commands=["id -u"],
-            commands_hash=sha256("id -u".encode()).hexdigest(),
+            commands_hash=sha256(b"id -u").hexdigest(),
             cluster=1002,
         )
 
@@ -397,13 +397,7 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
             payload_signature_to_label = {}
             labels = []
             for tokens in tokenized_sequences:
-                payload_urls = tuple(
-                    sorted(
-                        tokens[index + 2]
-                        for index in range(len(tokens) - 2)
-                        if tokens[index] == "PAYLOAD" and tokens[index + 1] == "REQUEST"
-                    )
-                )
+                payload_urls = tuple(sorted(token.split(":", maxsplit=1)[1] for token in tokens if token.startswith("PAYLOAD_REQUEST:") and ":" in token))
                 label = payload_signature_to_label.setdefault(payload_urls, len(payload_signature_to_label) + 700)
                 labels.append(label)
             return labels
@@ -465,8 +459,8 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
         expected_tokenized = tokenize(
             command_lines
             + [
-                "PAYLOAD REQUEST http://dup.example/a.sh",
-                "PAYLOAD REQUEST http://dup.example/b.sh",
+                "PAYLOAD_REQUEST:http://dup.example/a.sh",
+                "PAYLOAD_REQUEST:http://dup.example/b.sh",
             ]
         )
         self.assertEqual(clustering_input, [expected_tokenized])

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -1,7 +1,8 @@
+from hashlib import sha256
 from unittest.mock import patch
 
 from greedybear.cronjobs.commands.cluster import ClusterCommandSequences, tokenize
-from greedybear.models import CommandSequence
+from greedybear.models import IOC, CommandSequence, CowrieSession, IocType
 
 from . import CustomTestCase
 
@@ -149,3 +150,49 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
                 call_args = mock_bulk.call_args
                 self.assertIn("cluster", call_args[0][1])
                 self.assertEqual(call_args[1].get("batch_size"), 1000)
+
+    def test_run_adds_payload_request_observables_to_clustering_input(self):
+        """
+        Payload URLs related to scanner IOCs are added as synthetic commands before tokenization.
+        """
+        CowrieSession.objects.all().delete()
+        CommandSequence.objects.all().delete()
+
+        command_lines = ["uname -a"]
+        command_sequence = CommandSequence.objects.create(
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            commands=command_lines,
+            commands_hash=sha256("\n".join(command_lines).encode()).hexdigest(),
+            cluster=3,
+        )
+        scanner_ioc = IOC.objects.create(
+            name="203.0.113.10",
+            type=IocType.IP.value,
+            scanner=True,
+        )
+        payload_ioc = IOC.objects.create(
+            name="payload.example.com",
+            type=IocType.DOMAIN.value,
+            payload_request=True,
+            related_urls=["http://payload.example.com/a.sh"],
+        )
+        scanner_ioc.related_ioc.add(payload_ioc)
+        CowrieSession.objects.create(
+            session_id=int("abcabcabcabc", 16),
+            start_time=self.current_time,
+            duration=1.0,
+            source=scanner_ioc,
+            commands=command_sequence,
+        )
+
+        with patch("greedybear.cronjobs.commands.cluster.LSHConnectedComponents") as mock_lsh_cls:
+            mock_lsh_cls.return_value.get_components.return_value = [42]
+            ClusterCommandSequences().run()
+
+            clustering_input = mock_lsh_cls.return_value.get_components.call_args[0][0]
+
+        expected_tokenized = tokenize(command_lines + ["PAYLOAD REQUEST http://payload.example.com/a.sh"])
+        self.assertEqual(clustering_input, [expected_tokenized])
+        command_sequence.refresh_from_db()
+        self.assertEqual(command_sequence.cluster, 42)

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -196,3 +196,48 @@ class ClusterCommandSequencesTestCase(CustomTestCase):
         self.assertEqual(clustering_input, [expected_tokenized])
         command_sequence.refresh_from_db()
         self.assertEqual(command_sequence.cluster, 42)
+
+    def test_run_ignores_payload_request_observables_from_non_scanner_sources(self):
+        """
+        Payload URLs linked through non-scanner sources are ignored for clustering input.
+        """
+        CowrieSession.objects.all().delete()
+        CommandSequence.objects.all().delete()
+
+        command_lines = ["uname -a"]
+        command_sequence = CommandSequence.objects.create(
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            commands=command_lines,
+            commands_hash=sha256("\n".join(command_lines).encode()).hexdigest(),
+            cluster=5,
+        )
+        non_scanner_ioc = IOC.objects.create(
+            name="198.51.100.15",
+            type=IocType.IP.value,
+            scanner=False,
+        )
+        payload_ioc = IOC.objects.create(
+            name="payload.example.net",
+            type=IocType.DOMAIN.value,
+            payload_request=True,
+            related_urls=["http://payload.example.net/b.sh"],
+        )
+        non_scanner_ioc.related_ioc.add(payload_ioc)
+        CowrieSession.objects.create(
+            session_id=int("defdefdefdef", 16),
+            start_time=self.current_time,
+            duration=1.0,
+            source=non_scanner_ioc,
+            commands=command_sequence,
+        )
+
+        with patch("greedybear.cronjobs.commands.cluster.LSHConnectedComponents") as mock_lsh_cls:
+            mock_lsh_cls.return_value.get_components.return_value = [77]
+            ClusterCommandSequences().run()
+
+            clustering_input = mock_lsh_cls.return_value.get_components.call_args[0][0]
+
+        self.assertEqual(clustering_input, [tokenize(command_lines)])
+        command_sequence.refresh_from_db()
+        self.assertEqual(command_sequence.cluster, 77)


### PR DESCRIPTION
# Description

This PR extends command-sequence clustering to also consider payload-request observables by reusing the existing LSH clustering pipeline. For each command sequence, payload URLs related through scanner IOC relationships are appended as synthetic commands (`PAYLOAD REQUEST <url>`) before tokenization, so attackers with identical payload requests can be clustered together with no new clustering model.

### Related issues

- Closes #523
- Follows up on #522 (payload-request-based correlation direction)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [ ] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [ ] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
