### PR TITLE
fix(extraction): apply parse_timestamp() to Cowrie session hit["timestamp"] fields. Closes #1193

### DIFF
--- a/greedybear/cronjobs/extraction/strategies/cowrie.py
+++ b/greedybear/cronjobs/extraction/strategies/cowrie.py
@@ -233,7 +233,7 @@ class CowrieExtractionStrategy(BaseExtractionStrategy):
 
         match eventid:
             case "cowrie.session.connect":
-                session_record.start_time = hit["timestamp"]
+                session_record.start_time = parse_timestamp(hit["timestamp"])
 
             case "cowrie.login.failed" | "cowrie.login.success":
                 session_record.login_attempt = True
@@ -247,10 +247,10 @@ class CowrieExtractionStrategy(BaseExtractionStrategy):
 
                 if session_record.commands is None:
                     session_record.commands = CommandSequence()
-                    session_record.commands.first_seen = hit["timestamp"]
+                    session_record.commands.first_seen = parse_timestamp(hit["timestamp"])
 
                 command = normalize_command(hit["message"])
-                session_record.commands.last_seen = hit["timestamp"]
+                session_record.commands.last_seen = parse_timestamp(hit["timestamp"])
                 session_record.commands.commands.append(command)
 
             case "cowrie.session.closed":
@@ -261,7 +261,7 @@ class CowrieExtractionStrategy(BaseExtractionStrategy):
                 if shasum:
                     url = hit.get("url", "")
                     outfile = hit.get("outfile", "")
-                    timestamp = hit["timestamp"]
+                    timestamp = parse_timestamp(hit["timestamp"])
                     self.log.info(f"found file with shasum {shasum[:8]}... from {ioc.name}")
 
                     self.session_repo.get_or_create_file_transfer(

--- a/tests/test_cowrie_extraction.py
+++ b/tests/test_cowrie_extraction.py
@@ -276,6 +276,9 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
         self.assertTrue(session_record.command_execution)
         self.assertIsInstance(session_record.commands, CommandSequence)
         self.assertEqual(session_record.commands.first_seen, datetime(2023, 1, 1, 10, 0, 5))
+        self.assertIsNone(session_record.commands.first_seen.tzinfo)
+        self.assertEqual(session_record.commands.last_seen, datetime(2023, 1, 1, 10, 0, 5))
+        self.assertIsNone(session_record.commands.last_seen.tzinfo)
         self.assertIn("ls -la", session_record.commands.commands)
 
     def test_process_session_hit_session_closed(self):
@@ -404,7 +407,7 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
         session = Mock()
         session.commands = Mock()
         session.commands.commands = ["ls", "pwd", "whoami"]
-        session.commands.last_seen = "2023-01-01T10:00:10"
+        session.commands.last_seen = datetime(2023, 1, 1, 10, 0, 10)
 
         existing_cmd_seq = Mock()
         self.mock_session_repo.get_command_sequence_by_hash.return_value = existing_cmd_seq
@@ -413,7 +416,8 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
 
         self.assertTrue(result)
         self.assertEqual(session.commands, existing_cmd_seq)
-        self.assertEqual(session.commands.last_seen, "2023-01-01T10:00:10")
+        self.assertIsInstance(session.commands.last_seen, datetime)
+        self.assertIsNone(session.commands.last_seen.tzinfo)
 
     def test_start_time_is_naive_datetime_not_string(self):
         """Regression: parse_timestamp() must be called so that timezone-aware

--- a/tests/test_cowrie_extraction.py
+++ b/tests/test_cowrie_extraction.py
@@ -2,6 +2,7 @@
 Tests for Cowrie extraction helper functions and strategy.
 """
 
+from datetime import datetime
 from unittest.mock import MagicMock, Mock, patch
 
 from greedybear.cronjobs.extraction.strategies.cowrie import (
@@ -233,7 +234,8 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
 
         self.strategy._process_session_hit(session_record, hit, ioc)
 
-        self.assertEqual(session_record.start_time, "2023-01-01T10:00:00")
+        self.assertEqual(session_record.start_time, datetime(2023, 1, 1, 10, 0, 0))
+        self.assertIsNone(session_record.start_time.tzinfo)
         self.assertEqual(session_record.interaction_count, 1)
 
     def test_process_session_hit_login_failed(self):
@@ -273,7 +275,7 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
 
         self.assertTrue(session_record.command_execution)
         self.assertIsInstance(session_record.commands, CommandSequence)
-        self.assertEqual(session_record.commands.first_seen, "2023-01-01T10:00:05")
+        self.assertEqual(session_record.commands.first_seen, datetime(2023, 1, 1, 10, 0, 5))
         self.assertIn("ls -la", session_record.commands.commands)
 
     def test_process_session_hit_session_closed(self):
@@ -312,7 +314,7 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
             shasum="abc123def456",
             url="http://malware.com/bad.exe",
             outfile="/data/cowrie/downloads/bad.exe",
-            timestamp="2023-01-01T10:00:04",
+            timestamp=datetime(2023, 1, 1, 10, 0, 4),
         )
         self.assertEqual(session_record.interaction_count, 1)
 
@@ -337,7 +339,7 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
             shasum="deadbeef123456",
             url="",  # upload events do not contain URL
             outfile="/var/lib/cowrie/downloads/deadbeef123456",
-            timestamp="2023-01-01T10:00:04",
+            timestamp=datetime(2023, 1, 1, 10, 0, 4),
         )
         self.assertEqual(session_record.interaction_count, 1)
 
@@ -412,6 +414,22 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
         self.assertTrue(result)
         self.assertEqual(session.commands, existing_cmd_seq)
         self.assertEqual(session.commands.last_seen, "2023-01-01T10:00:10")
+
+    def test_start_time_is_naive_datetime_not_string(self):
+        """Regression: parse_timestamp() must be called so that timezone-aware
+        Elasticsearch strings are stripped to naive datetimes before .save().
+        Without the fix, USE_TZ=False causes a ValueError on PostgreSQL."""
+        session_record = Mock()
+        session_record.interaction_count = 0
+        hit = {
+            "eventid": "cowrie.session.connect",
+            "timestamp": "2025-06-01T12:00:00.000000+00:00",
+        }
+
+        self.strategy._process_session_hit(session_record, hit, Mock())
+
+        self.assertIsInstance(session_record.start_time, datetime)
+        self.assertIsNone(session_record.start_time.tzinfo)
 
     @patch("greedybear.cronjobs.extraction.strategies.cowrie.iocs_from_hits")
     def test_extract_from_hits_integration(self, mock_iocs_from_hits):

--- a/tests/test_cowrie_session_repository.py
+++ b/tests/test_cowrie_session_repository.py
@@ -110,7 +110,7 @@ class TestCowrieSessionRepository(CustomTestCase):
             shasum="abc123def456",
             url="http://malware.com/bad.exe",
             outfile="/data/cowrie/downloads/bad.exe",
-            timestamp="2023-01-01T10:00:04",
+            timestamp=datetime(2023, 1, 1, 10, 0, 4),
         )
 
         self.assertIsNotNone(transfer.pk)
@@ -118,7 +118,7 @@ class TestCowrieSessionRepository(CustomTestCase):
         self.assertEqual(transfer.shasum, "abc123def456")
         self.assertEqual(transfer.url, "http://malware.com/bad.exe")
         self.assertEqual(transfer.outfile, "/data/cowrie/downloads/bad.exe")
-        self.assertEqual(transfer.timestamp, "2023-01-01T10:00:04")
+        self.assertEqual(transfer.timestamp, datetime(2023, 1, 1, 10, 0, 4))
 
     def test_get_or_create_file_transfer_updates_timestamp(self):
         session = self.cowrie_session
@@ -128,7 +128,7 @@ class TestCowrieSessionRepository(CustomTestCase):
             shasum="abc123def456",
             url="http://malware.com/bad.exe",
             outfile="/data/cowrie/downloads/bad.exe",
-            timestamp="2023-01-01T10:00:04",
+            timestamp=datetime(2023, 1, 1, 10, 0, 4),
         )
 
         transfer = self.repo.get_or_create_file_transfer(
@@ -136,11 +136,11 @@ class TestCowrieSessionRepository(CustomTestCase):
             shasum="abc123def456",
             url="http://malware.com/ignored.exe",
             outfile="/data/cowrie/downloads/ignored.exe",
-            timestamp="2023-01-02T10:00:04",
+            timestamp=datetime(2023, 1, 2, 10, 0, 4),
         )
 
         self.assertEqual(transfer.pk, existing.pk)
-        self.assertEqual(transfer.timestamp, "2023-01-02T10:00:04")
+        self.assertEqual(transfer.timestamp, datetime(2023, 1, 2, 10, 0, 4))
         self.assertEqual(
             CowrieFileTransfer.objects.filter(session=session, shasum="abc123def456").count(),
             1,


### PR DESCRIPTION
# Description

`_process_session_hit()` in `extraction/strategies/cowrie.py` was assigning raw
Elasticsearch `timestamp` strings directly to `DateTimeField` attributes:

```python
session_record.start_time = hit["timestamp"]
session_record.commands.first_seen = hit["timestamp"]
session_record.commands.last_seen  = hit["timestamp"]
timestamp = hit["timestamp"]   # passed to get_or_create_file_transfer
```

`parse_timestamp()` already exists in `extraction/utils.py` specifically to handle
this — it parses the ISO string and strips timezone info with `.replace(tzinfo=None)`.
It was introduced in #1004 to fix the same class of problem for `hit["@timestamp"]`,
and it is already imported in `cowrie.py` (line 14). But `_process_session_hit()`
was never updated to use it for `hit["timestamp"]`.

Cowrie's `timestamp` field can carry timezone offsets (`+00:00`). With `USE_TZ = False`
in `settings.py`, Django raises `ValueError: Cannot use a timezone-aware datetime when
USE_TZ is False` during `get_db_prep_save()` when such a string reaches the ORM on
`.save()`. This silently drops all session data — `CowrieSession.start_time`,
`CommandSequence.first_seen`/`last_seen`, and `CowrieFileTransfer.timestamp` — for
any extraction run where a Cowrie connect, command, or file transfer event carries
a UTC-offset timestamp.

The unit tests were not catching this because they use `Mock()`, which stores
whatever value you assign without running Django field logic. Five test assertions
were comparing raw strings against `DateTimeField` attributes, so the bug was
passing all checks.

This PR applies `parse_timestamp()` to all four assignments, updates the five
broken test assertions to compare `datetime` objects, and adds a regression test
that passes a timezone-aware timestamp string and asserts the result is a naive
`datetime` with `tzinfo=None`.

### Related issues

Closes #1193 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [ ] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Not applicable — backend-only change.
