### PR TITLE
Cache get_valid_feed_types() to reduce DB load in feed endpoints

### DIFF
--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -146,9 +146,16 @@ def get_valid_feed_types() -> frozenset[str]:
     Returns:
         frozenset[str]: An immutable set of valid feed type strings
     """
+    cache_key = "valid_feed_types"
+    cached_types = cache.get(cache_key)
+    if cached_types is not None:
+        return cached_types
+
     honeypots = Honeypot.objects.filter(active=True)
     feed_types = ["all"] + [hp.name.lower() for hp in honeypots]
-    return frozenset(feed_types)
+    result = frozenset(feed_types)
+    cache.set(cache_key, result, (settings.EXTRACTION_INTERVAL + 5) * 60)
+    return result
 
 
 def get_queryset(request, feed_params, valid_feed_types, is_aggregated=False, serializer_class=FeedsRequestSerializer, tag_key="", tag_value=""):

--- a/greedybear/apps.py
+++ b/greedybear/apps.py
@@ -8,3 +8,4 @@ class GreedyBearConfig(AppConfig):
 
     def ready(self):
         import greedybear.checks  # noqa: F401 — register system checks
+        import greedybear.signals  # noqa: F401 — register signals

--- a/greedybear/signals.py
+++ b/greedybear/signals.py
@@ -1,0 +1,11 @@
+from django.core.cache import cache
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from greedybear.models import Honeypot
+
+
+@receiver(post_save, sender=Honeypot)
+@receiver(post_delete, sender=Honeypot)
+def invalidate_valid_feed_types_cache(sender, instance, **kwargs):
+    cache.delete("valid_feed_types")


### PR DESCRIPTION
# Description

enhancement: cache `get_valid_feed_types()` to reduce database load on feed endpoints

All four feed endpoints invoke `get_valid_feed_types()` on every request, leading to redundant database connection checkouts. Since active honeypot records change infrequently (~20–30 rows), the result is now cached with a 15-minute TTL.

**Changes:**

- Cache the return value of `get_valid_feed_types()` under the key `"valid_feed_types"` with a 15-minute TTL in `api/views/utils.py`
- Introduce `greedybear/signals.py` with `post_save` and `post_delete` receivers on the `Honeypot` model to immediately invalidate the cache whenever honeypot configuration is modified
- Register the signals module via `GreedyBearConfig.ready()` in `greedybear/apps.py`

Closes #952

---

### Related issues

#952 Optimization: Caching `get_valid_feed_types()`

---

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

---

# Checklist

### Formalities

- [x] I have read and understood the rules about [[how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/)](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I have chosen an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request targets the `develop` branch.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I have documented my code changes with docstrings and/or comments.
- [x] I have verified whether my changes affect user-facing behavior described in the [[docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/)](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I have also submitted a pull request to the [[docs repository](https://github.com/intelowlproject/docs)](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) reported 0 errors. If [[pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance)](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance) is correctly installed, these checks and fixes are applied automatically.
- [ ] I have added tests covering the feature/bug addressed in this PR.
- [x] All tests passed with 0 errors.