### PR TITLE
Fix env-dependent test crash in extraction strategies. Closes #1201

### DIFF
--- a/tests/test_cowrie_extraction.py
+++ b/tests/test_cowrie_extraction.py
@@ -4,6 +4,8 @@ Tests for Cowrie extraction helper functions and strategy.
 
 from unittest.mock import MagicMock, Mock, patch
 
+from django.test import override_settings
+
 from greedybear.cronjobs.extraction.strategies.cowrie import (
     CowrieExtractionStrategy,
     normalize_command,
@@ -88,6 +90,7 @@ class TestHelperFunctions(ExtractionTestCase):
         self.assertEqual(result, short_field)
 
 
+@override_settings(THREATFOX_API_KEY="")
 class TestCowrieExtractionStrategy(ExtractionTestCase):
     """Test CowrieExtractionStrategy class."""
 
@@ -195,6 +198,7 @@ class TestCowrieExtractionStrategy(ExtractionTestCase):
 
         self.mock_ioc_repo.get_ioc_by_name.side_effect = [scanner_mock, payload_mock]
         mock_payload_record = Mock()
+        mock_payload_record.payload_request = False
         mock_payload_record.honeypots.all.return_value = []
         self.strategy.ioc_processor.add_ioc.return_value = mock_payload_record
 

--- a/tests/test_extraction_strategies.py
+++ b/tests/test_extraction_strategies.py
@@ -1,11 +1,14 @@
 from unittest.mock import Mock, patch
 
+from django.test import override_settings
+
 from greedybear.consts import SCANNER
 from greedybear.cronjobs.extraction.strategies import GenericExtractionStrategy
 
 from . import ExtractionTestCase
 
 
+@override_settings(THREATFOX_API_KEY="")
 class TestGenericExtractionStrategy(ExtractionTestCase):
     def setUp(self):
         super().setUp()

--- a/tests/test_heralding_strategy.py
+++ b/tests/test_heralding_strategy.py
@@ -4,6 +4,8 @@ Tests for the Heralding credential-catching honeypot extraction strategy.
 
 from unittest.mock import Mock, patch
 
+from django.test import override_settings
+
 from greedybear.consts import SCANNER
 from greedybear.cronjobs.extraction.strategies.heralding import (
     HERALDING_HONEYPOT,
@@ -15,6 +17,7 @@ from greedybear.cronjobs.extraction.strategies.heralding import (
 from . import ExtractionTestCase
 
 
+@override_settings(THREATFOX_API_KEY="")
 class TestHeraldingExtractionStrategy(ExtractionTestCase):
     """Tests for the main extract_from_hits entrypoint."""
 
@@ -147,6 +150,7 @@ class TestHeraldingProtocolExtraction(ExtractionTestCase):
         self.assertIsNone(result)
 
 
+@override_settings(THREATFOX_API_KEY="")
 class TestHeraldingCredentialClassification(ExtractionTestCase):
     """Tests for _classify_credential_attacks and credential persistence logic."""
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -213,7 +213,6 @@ class FeedsRequestSerializersTestCase(CustomTestCase):
             self.assertIn("paginate", serializer.errors)
             self.assertIn("format", serializer.errors)
 
-
     def _base_request_data(self):
         return {
             "feed_type": "all",

--- a/tests/test_tanner_strategy.py
+++ b/tests/test_tanner_strategy.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock, patch
 
+from django.test import override_settings
+
 from greedybear.consts import PAYLOAD_REQUEST, SCANNER
 from greedybear.cronjobs.extraction.strategies.tanner import (
     TANNER_ATTACK_PATTERNS,
@@ -10,6 +12,7 @@ from greedybear.cronjobs.extraction.strategies.tanner import (
 from . import ExtractionTestCase
 
 
+@override_settings(THREATFOX_API_KEY="")
 class TestTannerExtractionStrategy(ExtractionTestCase):
     def setUp(self):
         super().setUp()
@@ -226,6 +229,7 @@ class TestTannerRequestTextExtraction(ExtractionTestCase):
         self.assertIn("/from-url", text)
 
 
+@override_settings(THREATFOX_API_KEY="")
 class TestTannerAttackClassification(ExtractionTestCase):
     def setUp(self):
         super().setUp()
@@ -345,6 +349,7 @@ class TestTannerAttackClassification(ExtractionTestCase):
         self.assertEqual(self.strategy.attack_tags_added, 0)
 
 
+@override_settings(THREATFOX_API_KEY="")
 class TestTannerRfiExtraction(ExtractionTestCase):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
# Description

When `THREATFOX_API_KEY` is present in `.env`, `test_get_url_downloads` (and potentially other extraction strategy tests) crash with `TypeError: can only join an iterable`.

**Root cause:** The `mock_payload_record` in `test_get_url_downloads` was an unconfigured `Mock()`. When the real `settings.THREATFOX_API_KEY` leaked into `threatfox_submission()`, the function checked `ioc_record.payload_request` (truthy `<Mock>`), then `hasattr(ioc_record, "_seen_honeypots")` (also `True` on Mock), and finally `", ".join(<Mock>)` crashed.

**Fix (two layers):**
1. Set `mock_payload_record.payload_request = False` — properly configures the mock to match the expected contract.
2. Add `@override_settings(THREATFOX_API_KEY="")` on all extraction strategy test classes that call `extract_from_hits` → `threatfox_submission` — this makes tests deterministic regardless of local `.env`, matching the isolation approach already used by `test_slack.py`, `test_ntfy.py`, etc.

### Related issues

Closes #1201

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

_N/A — no GUI changes._
