### PR TITLE
Migrate tor_exit_nodes HTTP client to httpx (part of #1214)

### DIFF
--- a/greedybear/cronjobs/tor_exit_nodes.py
+++ b/greedybear/cronjobs/tor_exit_nodes.py
@@ -1,6 +1,6 @@
 import re
 
-import requests
+import httpx
 
 from greedybear.cronjobs.base import Cronjob
 from greedybear.cronjobs.extraction.utils import is_valid_ipv4
@@ -24,9 +24,9 @@ class TorExitNodesCron(Cronjob):
         try:
             self.log.info("Starting download of Tor exit node list from torproject.org")
 
-            r = requests.get(
+            r = httpx.get(
                 "https://check.torproject.org/exit-addresses",
-                timeout=10,
+                timeout=10.0,
             )
             r.raise_for_status()
 
@@ -45,6 +45,6 @@ class TorExitNodesCron(Cronjob):
 
             self.log.info("Completed download of Tor exit node list")
 
-        except requests.RequestException as e:
+        except httpx.HTTPError as e:
             self.log.error(f"Failed to fetch Tor exit nodes: {e}")
             raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "feedparser==6.0.12",
     "stix2==3.0.2",
     # Utilities
+    "httpx==0.28.1",
     "requests==2.33.1",
     "slack-sdk==3.41.0",
 ]

--- a/tests/test_tor.py
+++ b/tests/test_tor.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 
-import requests
+import httpx
 
 from greedybear.cronjobs.repositories.tor import TorRepository
 from greedybear.cronjobs.tor_exit_nodes import TorExitNodesCron
@@ -52,14 +52,14 @@ class TestTorExitNodesCron(CustomTestCase):
         self.mock_ioc_repo = Mock()
         self.cron = TorExitNodesCron(tor_repo=self.mock_tor_repo, ioc_repo=self.mock_ioc_repo)
 
-    @patch("greedybear.cronjobs.tor_exit_nodes.requests.get")
+    @patch("greedybear.cronjobs.tor_exit_nodes.httpx.get")
     @patch("greedybear.cronjobs.tor_exit_nodes.is_valid_ipv4")
-    def test_run_success(self, mock_is_valid, mock_requests_get):
+    def test_run_success(self, mock_is_valid, mock_httpx_get):
         """Test successful Tor exit nodes fetching."""
         # Arrange
         mock_response = Mock()
         mock_response.text = "ExitAddress 1.2.3.4\\nExitAddress 5.6.7.8"
-        mock_requests_get.return_value = mock_response
+        mock_httpx_get.return_value = mock_response
 
         # Mock validation to return valid for both IPs
         mock_is_valid.side_effect = [(True, "1.2.3.4"), (True, "5.6.7.8")]
@@ -71,16 +71,16 @@ class TestTorExitNodesCron(CustomTestCase):
         self.cron.run()
 
         # Assert
-        mock_requests_get.assert_called_once_with("https://check.torproject.org/exit-addresses", timeout=10)
+        mock_httpx_get.assert_called_once_with("https://check.torproject.org/exit-addresses", timeout=10.0)
         self.assertEqual(self.mock_tor_repo.get_or_create.call_count, 2)
         self.assertEqual(self.mock_ioc_repo.update_ioc_reputation.call_count, 2)
 
-    @patch("greedybear.cronjobs.tor_exit_nodes.requests.get")
-    def test_run_request_failure(self, mock_requests_get):
+    @patch("greedybear.cronjobs.tor_exit_nodes.httpx.get")
+    def test_run_request_failure(self, mock_httpx_get):
         """Test handling of request failures."""
         # Arrange
-        mock_requests_get.side_effect = requests.RequestException("Network error")
+        mock_httpx_get.side_effect = httpx.HTTPError("Network error")
 
         # Act & Assert
-        with self.assertRaises(requests.RequestException):
+        with self.assertRaises(httpx.HTTPError):
             self.cron.run()

--- a/uv.lock
+++ b/uv.lock
@@ -497,6 +497,7 @@ dependencies = [
     { name = "elasticsearch" },
     { name = "feedparser" },
     { name = "gunicorn" },
+    { name = "httpx" },
     { name = "joblib" },
     { name = "numpy" },
     { name = "pandas" },
@@ -530,6 +531,7 @@ requires-dist = [
     { name = "elasticsearch", specifier = "==9.3.0" },
     { name = "feedparser", specifier = "==6.0.12" },
     { name = "gunicorn", specifier = "==25.3.0" },
+    { name = "httpx", specifier = "==0.28.1" },
     { name = "joblib", specifier = "==1.5.3" },
     { name = "numpy", specifier = "==2.4.4" },
     { name = "pandas", specifier = "==3.0.2" },
@@ -558,6 +560,43 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/c8/8aaf447698c4d59aa853fd318eed300b5c9e44459f242ab8ead6c9c09792/gunicorn-25.3.0-py3-none-any.whl", hash = "sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660", size = 208403, upload-time = "2026-03-27T00:00:27.386Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

This PR migrates only the Tor exit nodes cronjob HTTP call from `requests` to `httpx`, while preserving existing behaviour.

Scope is intentionally small and low risk:
- Updated `greedybear/cronjobs/tor_exit_nodes.py` to use `httpx.get(...)`.
- Kept the same endpoint and timeout behaviour.
- Kept `raise_for_status()` handling and exception propagation behaviour.
- Updated Tor tests to patch/use the new HTTP client path and equivalent exception expectations.
- Added `httpx` dependency and updated lockfile.

This is an incremental step toward standardising HTTP usage in cron jobs, starting from a low-risk fetcher.

### Related issues

- #1214

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behaviour that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it runs these checks and makes these adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [ ] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.