### PR TITLE
fix: link source IPs to credentials in Heralding strategy. Closes #1233 

### DIFF
--- a/greedybear/cronjobs/extraction/strategies/heralding.py
+++ b/greedybear/cronjobs/extraction/strategies/heralding.py
@@ -85,12 +85,13 @@ class HeraldingExtractionStrategy(BaseExtractionStrategy):
 
         Extracts username/password pairs from Heralding hits and stores them
         together with the normalized protocol on the Credential model.
-        Duplicate tuples in the same batch are deduplicated.
+        Duplicate tuples in the same batch are deduplicated while preserving
+        the mapping to source IPs for linking via Credential.sources.
 
         Args:
             hits: List of Elasticsearch hit documents.
         """
-        credentials: set[tuple[str, str, str]] = set()
+        credentials: dict[tuple[str, str, str], set[str]] = {}
         for hit in hits:
             protocol = self._extract_protocol(hit)
             if not protocol:
@@ -103,14 +104,21 @@ class HeraldingExtractionStrategy(BaseExtractionStrategy):
 
             username = normalize_credential_field(raw_username)
             password = normalize_credential_field(raw_password)
-            credentials.add((username, password, protocol))
+            key = (username, password, protocol)
+            credentials.setdefault(key, set()).add(hit.get("src_ip", ""))
 
-        for username, password, protocol in sorted(credentials):
-            _, created = Credential.objects.get_or_create(
+        ioc_by_ip = {ioc.name: ioc for ioc in self.ioc_records}
+
+        for (username, password, protocol), src_ips in sorted(credentials.items()):
+            credential, created = Credential.objects.get_or_create(
                 username=username,
                 password=password,
                 protocol=protocol,
             )
+            for ip in src_ips:
+                ioc_record = ioc_by_ip.get(ip)
+                if ioc_record:
+                    credential.sources.add(ioc_record)
             if created:
                 self.credentials_added += 1
                 self.log.info(f"stored credential for protocol={protocol}")

--- a/tests/test_heralding_strategy.py
+++ b/tests/test_heralding_strategy.py
@@ -334,6 +334,56 @@ class TestHeraldingCredentialClassification(ExtractionTestCase):
             protocol="ssh",
         )
 
+    @patch("greedybear.cronjobs.extraction.strategies.heralding.iocs_from_hits")
+    @patch("greedybear.cronjobs.extraction.strategies.heralding.Credential.objects")
+    @patch("greedybear.cronjobs.extraction.strategies.heralding.threatfox_submission")
+    def test_credential_sources_linked(self, mock_threatfox, mock_credential_objects, mock_iocs_from_hits):
+        """Credentials are linked to their source IOC via credential.sources.add()."""
+        mock_credential = Mock()
+        mock_credential_objects.get_or_create.return_value = (mock_credential, True)
+        mock_ioc = self._create_mock_ioc("1.2.3.4")
+        mock_iocs_from_hits.return_value = [mock_ioc]
+        self.strategy.ioc_processor.add_ioc = Mock(return_value=mock_ioc)
+
+        hits = [{"src_ip": "1.2.3.4", "protocol": "ssh", "username": "root", "password": "toor", "@timestamp": "2025-01-01T00:00:00"}]
+        self.strategy.extract_from_hits(hits)
+
+        mock_credential.sources.add.assert_called_once_with(mock_ioc)
+
+    @patch("greedybear.cronjobs.extraction.strategies.heralding.iocs_from_hits")
+    @patch("greedybear.cronjobs.extraction.strategies.heralding.Credential.objects")
+    @patch("greedybear.cronjobs.extraction.strategies.heralding.threatfox_submission")
+    def test_credential_sources_multiple_ips(self, mock_threatfox, mock_credential_objects, mock_iocs_from_hits):
+        """Same credential from two IPs links both sources."""
+        mock_credential = Mock()
+        mock_credential_objects.get_or_create.return_value = (mock_credential, True)
+        ioc1 = self._create_mock_ioc("1.2.3.4")
+        ioc2 = self._create_mock_ioc("5.6.7.8")
+        mock_iocs_from_hits.return_value = [ioc1, ioc2]
+        self.strategy.ioc_processor.add_ioc = Mock(side_effect=[ioc1, ioc2])
+
+        hits = [
+            {"src_ip": "1.2.3.4", "protocol": "ssh", "username": "root", "password": "toor", "@timestamp": "2025-01-01T00:00:00"},
+            {"src_ip": "5.6.7.8", "protocol": "ssh", "username": "root", "password": "toor", "@timestamp": "2025-01-01T00:00:00"},
+        ]
+        self.strategy.extract_from_hits(hits)
+
+        linked_iocs = {call[0][0] for call in mock_credential.sources.add.call_args_list}
+        self.assertEqual(linked_iocs, {ioc1, ioc2})
+
+    @patch("greedybear.cronjobs.extraction.strategies.heralding.iocs_from_hits")
+    @patch("greedybear.cronjobs.extraction.strategies.heralding.Credential.objects")
+    def test_credential_sources_skipped_without_ioc(self, mock_credential_objects, mock_iocs_from_hits):
+        """Credentials from IPs without a matching IOC record are not linked."""
+        mock_credential = Mock()
+        mock_credential_objects.get_or_create.return_value = (mock_credential, True)
+        mock_iocs_from_hits.return_value = []
+
+        hits = [{"src_ip": "9.9.9.9", "protocol": "ssh", "username": "root", "password": "toor"}]
+        self.strategy.extract_from_hits(hits)
+
+        mock_credential.sources.add.assert_not_called()
+
 
 class TestHeraldingCredentialNormalization(ExtractionTestCase):
     """Tests for normalize_credential_field helper."""


### PR DESCRIPTION
# Description

This PR fixes a data omission issue where the Heralding extraction strategy was failing to link source IP models (`IOC`) to `Credential` models. 

Specifically, this includes:
- **Preserved Source Mappings**: Modified `_classify_credential_attacks` to use a dictionary accumulator, retaining the mapping of which source IPs hit which credential tuples during deduplication.
- **Added Source Linking**: Added `credential.sources.add(ioc_record)` immediately after `Credential.objects.get_or_create(...)` to correctly mirror the Cowrie implementation.
- **Robust Tests**: Added comprehensive test coverage in `test_heralding_strategy.py` explicitly asserting that source linking works for single IPs, multiple IPs, and safely fails when no IOC matches.

### Related issues

Closes #1233 

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `fix: link source IPs to credentials in Heralding strategy. Closes #1233 `
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`/ESLint) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.