### PR TITLE
feat: harden Django security settings for HTTPS deployments. Closes #1056

### DIFF
--- a/greedybear/settings.py
+++ b/greedybear/settings.py
@@ -59,6 +59,27 @@ with open(os.path.join(BASE_DIR, "pyproject.toml"), "rb") as f:
 CSRF_COOKIE_SAMESITE = "Strict"
 CSRF_COOKIE_HTTPONLY = True
 
+# Prevent browsers from MIME-sniffing the content type, reducing
+# the risk of drive-by downloads.
+SECURE_CONTENT_TYPE_NOSNIFF = True
+
+# Block framing of the site entirely to prevent clickjacking.
+# XFrameOptionsMiddleware is already in the middleware stack but
+# defaults to SAMEORIGIN; DENY is stricter and appropriate here
+# because GreedyBear has no legitimate need to be framed.
+X_FRAME_OPTIONS = "DENY"
+
+if STAGE_PRODUCTION:
+    # Mark session and CSRF cookies as Secure so they are only
+    # sent over HTTPS connections. Gated to production because
+    # local/CI environments run plain HTTP.
+    SESSION_COOKIE_SECURE = True
+    CSRF_COOKIE_SECURE = True
+    # NOTE: SECURE_SSL_REDIRECT is intentionally omitted. TLS is
+    # terminated at nginx, which already redirects HTTP -> HTTPS.
+    # Enabling it here would cause an infinite redirect loop because
+    # Django only sees plain HTTP from the gunicorn unix socket.
+
 # Read DJANGO_ALLOWED_HOSTS from env (comma-separated).
 # Falls back to ["*"] for backward compatibility.
 # For security checks, see greedybear/checks.py.

--- a/tests/greedybear/test_security_settings.py
+++ b/tests/greedybear/test_security_settings.py
@@ -1,0 +1,18 @@
+# This file is a part of GreedyBear https://github.com/honeynet/GreedyBear
+# See the file 'LICENSE' for copying permission.
+from django.conf import settings
+from django.test import SimpleTestCase
+
+
+class SecuritySettingsTests(SimpleTestCase):
+    def test_content_type_nosniff_enabled(self):
+        """SECURE_CONTENT_TYPE_NOSNIFF should always be True."""
+        self.assertTrue(settings.SECURE_CONTENT_TYPE_NOSNIFF)
+
+    def test_x_frame_options_deny(self):
+        """X_FRAME_OPTIONS should be DENY to block all framing."""
+        self.assertEqual(settings.X_FRAME_OPTIONS, "DENY")
+
+    def test_ssl_redirect_not_set(self):
+        """SECURE_SSL_REDIRECT must not be enabled (TLS terminates at nginx)."""
+        self.assertFalse(getattr(settings, "SECURE_SSL_REDIRECT", False))

--- a/tests/greedybear/test_security_settings.py
+++ b/tests/greedybear/test_security_settings.py
@@ -16,3 +16,15 @@ class SecuritySettingsTests(SimpleTestCase):
     def test_ssl_redirect_not_set(self):
         """SECURE_SSL_REDIRECT must not be enabled (TLS terminates at nginx)."""
         self.assertFalse(getattr(settings, "SECURE_SSL_REDIRECT", False))
+
+    def test_cookie_security_matches_environment(self):
+        """Cookies should only be marked secure in production."""
+        is_production = getattr(settings, "STAGE_PRODUCTION", False)
+        
+        # Test SESSION_COOKIE_SECURE
+        session_secure = getattr(settings, "SESSION_COOKIE_SECURE", False)
+        self.assertEqual(session_secure, is_production)
+        
+        # Test CSRF_COOKIE_SECURE
+        csrf_secure = getattr(settings, "CSRF_COOKIE_SECURE", False)
+        self.assertEqual(csrf_secure, is_production)

--- a/tests/greedybear/test_security_settings.py
+++ b/tests/greedybear/test_security_settings.py
@@ -20,11 +20,11 @@ class SecuritySettingsTests(SimpleTestCase):
     def test_cookie_security_matches_environment(self):
         """Cookies should only be marked secure in production."""
         is_production = getattr(settings, "STAGE_PRODUCTION", False)
-        
+
         # Test SESSION_COOKIE_SECURE
         session_secure = getattr(settings, "SESSION_COOKIE_SECURE", False)
         self.assertEqual(session_secure, is_production)
-        
+
         # Test CSRF_COOKIE_SECURE
         csrf_secure = getattr(settings, "CSRF_COOKIE_SECURE", False)
         self.assertEqual(csrf_secure, is_production)


### PR DESCRIPTION
# Description

As discussed in #1056, After looking at the deployment architecture, not all of the originally suggested settings are safe to apply:

- **`SECURE_SSL_REDIRECT`** is intentionally left out. TLS terminates at nginx, which already does the HTTP→HTTPS 301 redirect. Enabling this in Django would cause an infinite redirect loop since gunicorn only sees plain HTTP over the unix socket.
- **`SECURE_HSTS_SECONDS`** is also left out — this is nginx's responsibility in the current setup, and HSTS preload in particular is very hard to undo once deployed.

What this PR does add:
- `SECURE_CONTENT_TYPE_NOSNIFF = True` — prevents MIME-sniffing, safe for all environments
- `X_FRAME_OPTIONS = "DENY"` — the middleware was already active but defaulting to `SAMEORIGIN`
- `SESSION_COOKIE_SECURE = True` and `CSRF_COOKIE_SECURE = True` gated behind `STAGE_PRODUCTION` so local/CI setups aren't broken

### Related issues

Closes #1056

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/GreedyBear/Contribute/) to this project.
- [x] I chose an appropriate title for the pull request in the form: `feat: harden Django security settings for HTTPS deployments. Closes #1056 `
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://intelowlproject.github.io/docs/GreedyBear/Introduction/). If so, I also created a pull request in the [docs repository](https://github.com/intelowlproject/docs).
- [x] Linter (`Ruff`/ESLint) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/GreedyBear/Contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.