### PR TITLE
Fix bucket update logic. Closes #1246

### DIFF
--- a/greedybear/cronjobs/bucket_utils.py
+++ b/greedybear/cronjobs/bucket_utils.py
@@ -1,9 +1,10 @@
 import logging
 from collections import Counter
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from datetime import datetime
 from ipaddress import ip_address
-from typing import Any
+
+from elasticsearch.dsl.response import Hit
 
 from greedybear.cronjobs.extraction.utils import parse_timestamp
 from greedybear.cronjobs.repositories import TrendingBucketRepository
@@ -11,7 +12,6 @@ from greedybear.utils import is_non_global_ip
 
 logger = logging.getLogger(__name__)
 
-BucketHit = Mapping[str, Any]
 BucketKey = tuple[str, str, datetime]
 
 
@@ -20,10 +20,11 @@ def _bucket_start(timestamp: str) -> datetime:
     return parsed.replace(minute=0, second=0, microsecond=0)
 
 
-def _bucket_key_from_hit(hit: BucketHit) -> BucketKey | None:
-    attacker_ip = hit.get("src_ip")
-    feed_type = hit.get("type")
-    timestamp = hit.get("@timestamp")
+def _bucket_key_from_hit(hit: Hit) -> BucketKey | None:
+    hit_dict = hit.to_dict()
+    attacker_ip = hit_dict.get("src_ip")
+    feed_type = hit_dict.get("type")
+    timestamp = hit_dict.get("@timestamp")
     if not attacker_ip or not feed_type or not timestamp:
         return None
 
@@ -42,7 +43,7 @@ def _bucket_key_from_hit(hit: BucketHit) -> BucketKey | None:
         return None
 
 
-def update_activity_buckets_from_hits(hits: Iterable[BucketHit]) -> int:
+def update_activity_buckets_from_hits(hits: Iterable[Hit]) -> int:
     counters: Counter[BucketKey] = Counter()
     for hit in hits:
         key = _bucket_key_from_hit(hit)

--- a/tests/greedybear/cronjobs/test_trending.py
+++ b/tests/greedybear/cronjobs/test_trending.py
@@ -2,6 +2,7 @@ from datetime import datetime
 from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
+from elasticsearch.dsl.response import Hit
 
 from greedybear.cronjobs.bucket_cleanup import TrendingBucketCleanupCron
 from greedybear.cronjobs.bucket_utils import update_activity_buckets_from_hits
@@ -71,9 +72,9 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
 
         unique_keys = update_activity_buckets_from_hits(
             [
-                {"src_ip": "1.1.1.1", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "1.1.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:50:00"},
-                {"src_ip": "2.2.2.2", "type": "Heralding", "@timestamp": "2026-03-20T09:10:00"},
+                Hit({"_source": {"src_ip": "1.1.1.1", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "1.1.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:50:00"}}),
+                Hit({"_source": {"src_ip": "2.2.2.2", "type": "Heralding", "@timestamp": "2026-03-20T09:10:00"}}),
             ]
         )
 
@@ -96,10 +97,10 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
     def test_invalid_hits_are_ignored(self):
         unique_keys = update_activity_buckets_from_hits(
             [
-                {"src_ip": "", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "999.999.999.999", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "3.3.3.3", "type": "", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "3.3.3.3", "type": "cowrie"},
+                Hit({"_source": {"src_ip": "", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "999.999.999.999", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "3.3.3.3", "type": "", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "3.3.3.3", "type": "cowrie"}}),
             ]
         )
 
@@ -109,7 +110,7 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
     def test_invalid_timestamp_is_ignored(self):
         unique_keys = update_activity_buckets_from_hits(
             [
-                {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "not-a-timestamp"},
+                Hit({"_source": {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "not-a-timestamp"}}),
             ]
         )
         self.assertEqual(unique_keys, 0)
@@ -118,12 +119,12 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
     def test_non_global_ip_hits_are_ignored(self):
         unique_keys = update_activity_buckets_from_hits(
             [
-                {"src_ip": "10.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "127.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "224.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "169.254.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "240.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
-                {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                Hit({"_source": {"src_ip": "10.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "127.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "224.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "169.254.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "240.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                Hit({"_source": {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
             ]
         )
 
@@ -134,7 +135,7 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
     def test_global_ipv6_hit_is_counted(self):
         unique_keys = update_activity_buckets_from_hits(
             [
-                {"src_ip": "2001:4860:4860::8888", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                Hit({"_source": {"src_ip": "2001:4860:4860::8888", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
             ]
         )
         self.assertEqual(unique_keys, 1)
@@ -166,7 +167,7 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
 
     @patch("greedybear.cronjobs.bucket_utils.TrendingBucketRepository.upsert_bucket_counts", side_effect=Exception("db down"))
     def test_upsert_failure_returns_zero(self, mock_upsert):
-        unique_keys = update_activity_buckets_from_hits([{"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}])
+        unique_keys = update_activity_buckets_from_hits([Hit({"_source": {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}})])
         self.assertEqual(unique_keys, 0)
         mock_upsert.assert_called_once()
 


### PR DESCRIPTION
# Description

This fixes the described bug by converting the elasicsearch Hit object into a dict before calling the `get` method on it. 

### Related issues

Closes #1246

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [ ] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
