### PR TITLE
IOC identity: dedupe migration + uniqueness constraint. Refs #1240

### DIFF
--- a/greedybear/migrations/0051_ioc_identity_uniqueness_and_dedupe.py
+++ b/greedybear/migrations/0051_ioc_identity_uniqueness_and_dedupe.py
@@ -1,0 +1,84 @@
+from django.db import migrations, models
+
+
+def merge_duplicate_iocs(apps, schema_editor):
+    IOC = apps.get_model("greedybear", "IOC")
+    Tag = apps.get_model("greedybear", "Tag")
+    CowrieSession = apps.get_model("greedybear", "CowrieSession")
+
+    duplicates = IOC.objects.values("name", "type").annotate(cnt=models.Count("id")).filter(cnt__gt=1)
+
+    for dup in duplicates.iterator():
+        same_identity = list(IOC.objects.filter(name=dup["name"], type=dup["type"]).order_by("id"))
+        canonical = same_identity[0]
+        to_merge = same_identity[1:]
+
+        first_seen_values = [ioc.first_seen for ioc in same_identity if ioc.first_seen is not None]
+        if first_seen_values:
+            canonical.first_seen = min(first_seen_values)
+
+        last_seen_values = [ioc.last_seen for ioc in same_identity if ioc.last_seen is not None]
+        if last_seen_values:
+            canonical.last_seen = max(last_seen_values)
+
+        canonical.days_seen = sorted({day for ioc in same_identity for day in (ioc.days_seen or []) if day is not None})
+        canonical.number_of_days_seen = len(canonical.days_seen)
+        canonical.attack_count = sum((ioc.attack_count or 0) for ioc in same_identity)
+        canonical.interaction_count = sum((ioc.interaction_count or 0) for ioc in same_identity)
+        canonical.login_attempts = sum((ioc.login_attempts or 0) for ioc in same_identity)
+        canonical.scanner = any(ioc.scanner for ioc in same_identity)
+        canonical.payload_request = any(ioc.payload_request for ioc in same_identity)
+
+        canonical.related_urls = sorted({item for ioc in same_identity for item in (ioc.related_urls or []) if item})
+        canonical.destination_ports = sorted({item for ioc in same_identity for item in (ioc.destination_ports or []) if item is not None})
+        canonical.firehol_categories = sorted({item for ioc in same_identity for item in (ioc.firehol_categories or []) if item})
+
+        if not canonical.ip_reputation:
+            for ioc in same_identity:
+                if ioc.ip_reputation:
+                    canonical.ip_reputation = ioc.ip_reputation
+                    break
+
+        if not canonical.attacker_country:
+            for ioc in same_identity:
+                if ioc.attacker_country:
+                    canonical.attacker_country = ioc.attacker_country
+                    break
+
+        if not canonical.attacker_country_code:
+            for ioc in same_identity:
+                if ioc.attacker_country_code:
+                    canonical.attacker_country_code = ioc.attacker_country_code
+                    break
+
+        if canonical.autonomous_system_id is None:
+            for ioc in same_identity:
+                if ioc.autonomous_system_id is not None:
+                    canonical.autonomous_system_id = ioc.autonomous_system_id
+                    break
+
+        canonical.save()
+
+        for duplicate in to_merge:
+            canonical.honeypots.add(*duplicate.honeypots.all())
+            canonical.sensors.add(*duplicate.sensors.all())
+            canonical.credentials.add(*duplicate.credentials.all())
+
+            related_to_duplicate = duplicate.related_ioc.exclude(pk=canonical.pk)
+            if related_to_duplicate.exists():
+                canonical.related_ioc.add(*related_to_duplicate)
+
+            Tag.objects.filter(ioc_id=duplicate.pk).update(ioc_id=canonical.pk)
+            CowrieSession.objects.filter(source_id=duplicate.pk).update(source_id=canonical.pk)
+
+            duplicate.delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("greedybear", "0050_attackeractivitybucket"),
+    ]
+
+    operations = [
+        migrations.RunPython(merge_duplicate_iocs, migrations.RunPython.noop),
+    ]

--- a/greedybear/migrations/0052_ioc_unique_identity_constraint.py
+++ b/greedybear/migrations/0052_ioc_unique_identity_constraint.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("greedybear", "0051_ioc_identity_uniqueness_and_dedupe"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="ioc",
+            constraint=models.UniqueConstraint(fields=("name", "type"), name="unique_ioc_identity"),
+        ),
+    ]

--- a/greedybear/models.py
+++ b/greedybear/models.py
@@ -113,6 +113,9 @@ class IOC(models.Model):
     expected_interactions = models.FloatField(null=True, default=0)
 
     class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["name", "type"], name="unique_ioc_identity"),
+        ]
         indexes = [
             models.Index(fields=["name"]),
             models.Index(fields=["attacker_country"]),

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -261,3 +261,104 @@ class TestSensorLabelMigration(MigrationTestCase):
         sensor_new = new_state.apps.get_model(self.app_name, "Sensor")
         migrated = sensor_new.objects.get(address="10.0.0.1")
         self.assertEqual(migrated.label, "")
+
+
+@tag("migration")
+class TestIocIdentityUniquenessAndDedupe(MigrationTestCase):
+    """Tests IOC duplicate merge and identity uniqueness enforcement."""
+
+    migrate_from = "0050_attackeractivitybucket"
+    migrate_to = "0051_ioc_identity_uniqueness_and_dedupe"
+
+    def test_duplicate_iocs_are_merged(self):
+        from datetime import datetime, timedelta
+
+        IOC = self.old_state.apps.get_model(self.app_name, "IOC")
+        Honeypot = self.old_state.apps.get_model(self.app_name, "Honeypot")
+        Sensor = self.old_state.apps.get_model(self.app_name, "Sensor")
+        Tag = self.old_state.apps.get_model(self.app_name, "Tag")
+        CowrieSession = self.old_state.apps.get_model(self.app_name, "CowrieSession")
+
+        hp1, _ = Honeypot.objects.get_or_create(name="Cowrie", defaults={"active": True})
+        hp2, _ = Honeypot.objects.get_or_create(name="Heralding", defaults={"active": True})
+        s1 = Sensor.objects.create(address="10.10.10.1")
+        s2 = Sensor.objects.create(address="10.10.10.2")
+
+        now = datetime.now()
+        ioc1 = IOC.objects.create(
+            name="1.2.3.4",
+            type="ip",
+            first_seen=now - timedelta(days=3),
+            last_seen=now - timedelta(days=2),
+            attack_count=2,
+            interaction_count=5,
+            login_attempts=1,
+            related_urls=["http://a.example"],
+            destination_ports=[22],
+            firehol_categories=["scanner"],
+        )
+        ioc2 = IOC.objects.create(
+            name="1.2.3.4",
+            type="ip",
+            first_seen=now - timedelta(days=5),
+            last_seen=now - timedelta(days=1),
+            attack_count=3,
+            interaction_count=7,
+            login_attempts=4,
+            related_urls=["http://b.example"],
+            destination_ports=[80],
+            firehol_categories=["botnet"],
+            ip_reputation="tor_exit_node",
+        )
+        ioc_other_type = IOC.objects.create(name="1.2.3.4", type="domain")
+
+        ioc1.honeypots.add(hp1)
+        ioc2.honeypots.add(hp2)
+        ioc1.sensors.add(s1)
+        ioc2.sensors.add(s2)
+
+        Tag.objects.create(ioc=ioc2, key="source", value="threatfox", source="threatfox")
+        CowrieSession.objects.create(session_id=42, source=ioc2, interaction_count=3)
+
+        new_state = self.apply_tested_migration()
+        ioc_new = new_state.apps.get_model(self.app_name, "IOC")
+        tag_new = new_state.apps.get_model(self.app_name, "Tag")
+        cowrie_session_new = new_state.apps.get_model(self.app_name, "CowrieSession")
+
+        merged = ioc_new.objects.get(name="1.2.3.4", type="ip")
+        self.assertEqual(ioc_new.objects.filter(name="1.2.3.4", type="ip").count(), 1)
+        self.assertTrue(ioc_new.objects.filter(pk=ioc_other_type.pk, type="domain").exists())
+
+        self.assertEqual(merged.attack_count, 5)
+        self.assertEqual(merged.interaction_count, 12)
+        self.assertEqual(merged.login_attempts, 5)
+        self.assertEqual(merged.first_seen, now - timedelta(days=5))
+        self.assertEqual(merged.last_seen, now - timedelta(days=1))
+        self.assertEqual(sorted(merged.destination_ports), [22, 80])
+        self.assertEqual(sorted(merged.firehol_categories), ["botnet", "scanner"])
+        self.assertEqual(sorted(merged.related_urls), ["http://a.example", "http://b.example"])
+
+        self.assertEqual(merged.honeypots.count(), 2)
+        self.assertEqual(merged.sensors.count(), 2)
+        self.assertEqual(tag_new.objects.filter(ioc_id=merged.pk).count(), 1)
+        self.assertEqual(cowrie_session_new.objects.get(session_id=42).source_id, merged.pk)
+
+
+@tag("migration")
+class TestIocIdentityUniqueConstraint(MigrationTestCase):
+    """Tests IOC identity unique constraint added in migration 0052."""
+
+    migrate_from = "0051_ioc_identity_uniqueness_and_dedupe"
+    migrate_to = "0052_ioc_unique_identity_constraint"
+
+    def test_unique_constraint_is_enforced_after_migration(self):
+        IOC = self.old_state.apps.get_model(self.app_name, "IOC")
+        IOC.objects.create(name="9.9.9.9", type="ip")
+
+        new_state = self.apply_tested_migration()
+        ioc_new = new_state.apps.get_model(self.app_name, "IOC")
+
+        with self.assertRaises(IntegrityError):
+            ioc_new.objects.create(name="9.9.9.9", type="ip")
+
+        ioc_new.objects.create(name="9.9.9.9", type="domain")


### PR DESCRIPTION
This PR is **PR 1/2** from Discussion [#1236](https://github.com/GreedyBear-Project/GreedyBear/discussions/1236) and implements the data-layer part of Issue [#1240](https://github.com/GreedyBear-Project/GreedyBear/issues/1240).

It implements the data-layer hardening first:

1. deduplicate existing IOC rows by identity `(name, type)`
2. enforce DB uniqueness for IOC identity
3. add migration tests for both steps

The write-path hardening (concurrency-safe upsert/transaction handling) is intentionally left for **PR 2**.

### What changed

- Added IOC identity unique constraint in model metadata:
  - `UniqueConstraint(fields=["name", "type"], name="unique_ioc_identity")`
- Added data migration to merge duplicate IOC rows:
  - keeps canonical row per `(name, type)`
  - merges counters/timestamps/array fields
  - preserves relationships (`honeypots`, `sensors`, `credentials`, `related_ioc`)
  - remaps dependent records (`Tag`, `CowrieSession`)
- Split constraint into a separate migration step (to avoid Postgres pending-trigger edge cases during tests)
- Added migration tests:
  - dedupe behavior test (`0050 -> 0051`)
  - uniqueness enforcement test (`0051 -> 0052`)

### Related issues

- Discussion: [#1236](https://github.com/GreedyBear-Project/GreedyBear/discussions/1236)
- Follow-up implementation issue: [#1240](https://github.com/GreedyBear-Project/GreedyBear/issues/1240)
- Historical context:
  - [#967](https://github.com/GreedyBear-Project/GreedyBear/issues/967)
  - [#974](https://github.com/GreedyBear-Project/GreedyBear/pull/974)
  - [#1007](https://github.com/GreedyBear-Project/GreedyBear/issues/1007)
  - [#1010](https://github.com/GreedyBear-Project/GreedyBear/pull/1010)
  - [#1012](https://github.com/GreedyBear-Project/GreedyBear/issues/1012)
  - [#1019](https://github.com/GreedyBear-Project/GreedyBear/pull/1019)
  - [#1024](https://github.com/GreedyBear-Project/GreedyBear/pull/1024)

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Refs #1240` _(PR1 references #1240; PR2 is expected to close it)_
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [ ] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved.
- [x] All migration tests gave 0 errors (`tests.test_migrations` in Docker).

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.

# Notes for reviewers

- This PR focuses only on data-state correctness (dedupe + uniqueness).
- PR 2 will focus only on runtime write-path hardening and concurrent-write regression tests.
- This PR references #1240 but does not close it; PR 2 is expected to close #1240.
