### PR TITLE
Exclude disabled honeypots from activity buckets. Closes #1275

### DIFF
--- a/greedybear/admin.py
+++ b/greedybear/admin.py
@@ -8,6 +8,7 @@ from django.utils.translation import ngettext
 
 from greedybear.models import (
     IOC,
+    AttackerActivityBucket,
     CommandSequence,
     CowrieSession,
     Credential,
@@ -181,6 +182,16 @@ class IOCModelAdmin(admin.ModelAdmin):
     def get_queryset(self, request):
         """Override to optimize queries and avoid N+1 problems."""
         return super().get_queryset(request).select_related("autonomous_system").prefetch_related("sensors", "honeypots")
+
+
+@admin.register(AttackerActivityBucket)
+class AttackerActivityBucketAdmin(admin.ModelAdmin):
+    list_display = ["attacker_ip", "feed_type", "bucket_start", "interaction_count"]
+    list_filter = ["feed_type"]
+    search_fields = ["attacker_ip"]
+    search_help_text = "search for the attacker IP address"
+    date_hierarchy = "bucket_start"
+    ordering = ["-bucket_start"]
 
 
 @admin.register(Honeypot)

--- a/greedybear/cronjobs/bucket_utils.py
+++ b/greedybear/cronjobs/bucket_utils.py
@@ -4,8 +4,6 @@ from collections.abc import Iterable
 from datetime import datetime
 from ipaddress import ip_address
 
-from elasticsearch.dsl.response import Hit
-
 from greedybear.cronjobs.extraction.utils import parse_timestamp
 from greedybear.cronjobs.repositories import TrendingBucketRepository
 from greedybear.utils import is_non_global_ip
@@ -20,11 +18,10 @@ def _bucket_start(timestamp: str) -> datetime:
     return parsed.replace(minute=0, second=0, microsecond=0)
 
 
-def _bucket_key_from_hit(hit: Hit) -> BucketKey | None:
-    hit_dict = hit.to_dict()
-    attacker_ip = hit_dict.get("src_ip")
-    feed_type = hit_dict.get("type")
-    timestamp = hit_dict.get("@timestamp")
+def _bucket_key_from_hit(hit: dict) -> BucketKey | None:
+    attacker_ip = hit.get("src_ip")
+    feed_type = hit.get("type")
+    timestamp = hit.get("@timestamp")
     if not attacker_ip or not feed_type or not timestamp:
         return None
 
@@ -43,7 +40,7 @@ def _bucket_key_from_hit(hit: Hit) -> BucketKey | None:
         return None
 
 
-def update_activity_buckets_from_hits(hits: Iterable[Hit]) -> int:
+def update_activity_buckets_from_hits(hits: Iterable[dict]) -> int:
     counters: Counter[BucketKey] = Counter()
     for hit in hits:
         key = _bucket_key_from_hit(hit)

--- a/greedybear/cronjobs/extraction/bucket_updater.py
+++ b/greedybear/cronjobs/extraction/bucket_updater.py
@@ -31,12 +31,13 @@ class BucketUpdater:
         try:
             update_count = TrendingBucketRepository().upsert_bucket_counts(self.counters)
             logger.debug(f"Updated {update_count} buckets")
-            self.counters = Counter()
             self.total_update_count += update_count
             return update_count
         except Exception as exc:
             logger.error("Failed to update activity buckets from hits for current chunk: %s", exc, exc_info=True)
             return 0
+        finally:
+            self.counters = Counter()
 
 
 def _bucket_start(timestamp: str) -> datetime:

--- a/greedybear/cronjobs/extraction/bucket_updater.py
+++ b/greedybear/cronjobs/extraction/bucket_updater.py
@@ -13,6 +13,32 @@ logger = logging.getLogger(__name__)
 BucketKey = tuple[str, str, datetime]
 
 
+class BucketUpdater:
+    def __init__(self):
+        self.counters: Counter[BucketKey] = Counter()
+        self.total_update_count: int = 0
+
+    def collect_hits(self, hits: Iterable[dict]) -> None:
+        for hit in hits:
+            key = _bucket_key_from_hit(hit)
+            if key is not None:
+                self.counters[key] += 1
+
+    def update(self) -> int:
+        if not self.counters:
+            return 0
+
+        try:
+            update_count = TrendingBucketRepository().upsert_bucket_counts(self.counters)
+            logger.debug(f"Updated {update_count} buckets")
+            self.counters = Counter()
+            self.total_update_count += update_count
+            return update_count
+        except Exception as exc:
+            logger.error("Failed to update activity buckets from hits for current chunk: %s", exc, exc_info=True)
+            return 0
+
+
 def _bucket_start(timestamp: str) -> datetime:
     parsed = parse_timestamp(timestamp)
     return parsed.replace(minute=0, second=0, microsecond=0)
@@ -38,20 +64,3 @@ def _bucket_key_from_hit(hit: dict) -> BucketKey | None:
         return normalized_ip, str(feed_type).lower(), _bucket_start(timestamp)
     except Exception:
         return None
-
-
-def update_activity_buckets_from_hits(hits: Iterable[dict]) -> int:
-    counters: Counter[BucketKey] = Counter()
-    for hit in hits:
-        key = _bucket_key_from_hit(hit)
-        if key is not None:
-            counters[key] += 1
-
-    if not counters:
-        return 0
-
-    try:
-        return TrendingBucketRepository().upsert_bucket_counts(counters)
-    except Exception as exc:
-        logger.error("Failed to update activity buckets from hits for current chunk: %s", exc, exc_info=True)
-        return 0

--- a/greedybear/cronjobs/extraction/pipeline.py
+++ b/greedybear/cronjobs/extraction/pipeline.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 
 from django.core.cache import caches
 
-from greedybear.cronjobs.bucket_utils import update_activity_buckets_from_hits
+from greedybear.cronjobs.extraction.bucket_updater import BucketUpdater
 from greedybear.cronjobs.extraction.strategies.factory import ExtractionStrategyFactory
 from greedybear.cronjobs.repositories import (
     ElasticRepository,
@@ -53,12 +53,13 @@ class ExtractionPipeline:
         2. For each chunk, group hits by honeypot type and extract sensors
         3. Apply honeypot-specific extraction strategies
         4. Update IOC scores
+        5. Update activity buckets
 
         Returns:
             Number of IOC records processed.
         """
         ioc_record_count = 0
-        bucket_update_count = 0
+        bucket_updater = BucketUpdater()
         factory = ExtractionStrategyFactory(self.ioc_repo, self.sensor_repo)
 
         # 1. Search in chunks
@@ -95,8 +96,8 @@ class ExtractionPipeline:
                     self.log.info(f"Skipping honeypot {honeypot}")
                     continue
 
-                self.log.info(f"Updating activity buckets for honeypot {honeypot}")
-                bucket_update_count += update_activity_buckets_from_hits(hits)
+                self.log.info(f"Collect hits for activity buckets from honeypot {honeypot}")
+                bucket_updater.collect_hits(hits)
 
                 self.log.info(f"Extracting hits from honeypot {honeypot}")
                 strategy = factory.get_strategy(honeypot)
@@ -112,7 +113,11 @@ class ExtractionPipeline:
                 UpdateScores().score_only(ioc_records)
             ioc_record_count += len(ioc_records)
 
-        # 5. Invalidate API caches only if any IOC records were processed
+            # 5. Update activity buckets
+            self.log.info("Updating activity buckets")
+            bucket_updater.update()
+
+        # 6. Invalidate API caches only if any IOC records were processed
         if ioc_record_count > 0:
             # Use the shared DB-backed cache so the version bump is visible to
             # gunicorn API workers (LocMemCache is per-process).
@@ -123,7 +128,7 @@ class ExtractionPipeline:
             except ValueError:
                 shared_cache.set("asn_feeds_version", 2, timeout=None)
 
-        if bucket_update_count > 0:
+        if bucket_updater.total_update_count > 0:
             self.log.info("Invalidating feeds trending cache")
             shared_cache = caches["django-q"]
             try:

--- a/greedybear/cronjobs/extraction/pipeline.py
+++ b/greedybear/cronjobs/extraction/pipeline.py
@@ -67,8 +67,6 @@ class ExtractionPipeline:
             ioc_records = []
             hits_by_honeypot = defaultdict(list)
 
-            bucket_update_count += update_activity_buckets_from_hits(chunk)
-
             # 2. Group by honeypot
             self.log.info("Grouping hits by honeypot type")
             for hit in chunk:
@@ -96,6 +94,10 @@ class ExtractionPipeline:
                 if not self.ioc_repo.is_ready_for_extraction(honeypot):
                     self.log.info(f"Skipping honeypot {honeypot}")
                     continue
+
+                self.log.info(f"Updating activity buckets for honeypot {honeypot}")
+                bucket_update_count += update_activity_buckets_from_hits(hits)
+
                 self.log.info(f"Extracting hits from honeypot {honeypot}")
                 strategy = factory.get_strategy(honeypot)
                 try:

--- a/tests/greedybear/cronjobs/test_extraction_pipeline_edge_cases.py
+++ b/tests/greedybear/cronjobs/test_extraction_pipeline_edge_cases.py
@@ -98,7 +98,11 @@ class TestEdgeCases(E2ETestCase):
         ]
         pipeline.elastic_repo.search.return_value = [hits]
         pipeline.ioc_repo.is_empty.return_value = False
-        pipeline.ioc_repo.is_ready_for_extraction.return_value = False
+        pipeline.ioc_repo.is_ready_for_extraction.return_value = True
+
+        mock_strategy = MagicMock()
+        mock_strategy.ioc_records = []
+        mock_factory.return_value.get_strategy.return_value = mock_strategy
 
         shared_cache = MagicMock()
         mock_caches.__getitem__.return_value = shared_cache
@@ -109,6 +113,60 @@ class TestEdgeCases(E2ETestCase):
         _mock_update_activity.assert_called_once()
         shared_cache.incr.assert_called_once_with("trending_feeds_version")
         mock_scores.return_value.score_only.assert_not_called()
+
+    @patch("greedybear.cronjobs.extraction.pipeline.caches")
+    @patch("greedybear.cronjobs.extraction.pipeline.update_activity_buckets_from_hits", return_value=0)
+    @patch("greedybear.cronjobs.extraction.pipeline.UpdateScores")
+    @patch("greedybear.cronjobs.extraction.pipeline.ExtractionStrategyFactory")
+    def test_disabled_honeypot_hits_do_not_update_activity_buckets(self, mock_factory, mock_scores, mock_update_activity, mock_caches):
+        """Hits from honeypots not ready for extraction must be excluded from bucket updates."""
+        pipeline = self._create_pipeline_with_real_factory()
+        pipeline.log = MagicMock()
+
+        hits = [
+            MockElasticHit({"src_ip": "1.1.1.1", "type": "DisabledHoneypot"}),
+            MockElasticHit({"src_ip": "1.1.1.1", "type": "DisabledHoneypot"}),
+            MockElasticHit({"src_ip": "2.2.2.2", "type": "EnabledHoneypot"}),
+        ]
+        pipeline.elastic_repo.search.return_value = [hits]
+        pipeline.ioc_repo.is_empty.return_value = False
+        pipeline.ioc_repo.is_ready_for_extraction.side_effect = lambda hp: hp == "EnabledHoneypot"
+
+        mock_strategy = MagicMock()
+        mock_strategy.ioc_records = []
+        mock_factory.return_value.get_strategy.return_value = mock_strategy
+
+        shared_cache = MagicMock()
+        mock_caches.__getitem__.return_value = shared_cache
+
+        pipeline.execute()
+
+        # update_activity_buckets_from_hits must be called exactly once, only with hits from the enabled honeypot.
+        mock_update_activity.assert_called_once()
+        passed_hits = list(mock_update_activity.call_args.args[0])
+        self.assertEqual(len(passed_hits), 1)
+        self.assertEqual(passed_hits[0]["type"], "EnabledHoneypot")
+        self.assertEqual(passed_hits[0]["src_ip"], "2.2.2.2")
+
+    @patch("greedybear.cronjobs.extraction.pipeline.UpdateScores")
+    @patch("greedybear.cronjobs.extraction.pipeline.ExtractionStrategyFactory")
+    def test_all_honeypots_disabled_skips_bucket_updates_entirely(self, mock_factory, mock_scores):
+        """When every honeypot in a chunk is disabled, activity buckets are never touched."""
+        pipeline = self._create_pipeline_with_real_factory()
+        pipeline.log = MagicMock()
+
+        hits = [
+            MockElasticHit({"src_ip": "1.1.1.1", "type": "DisabledA"}),
+            MockElasticHit({"src_ip": "2.2.2.2", "type": "DisabledB"}),
+        ]
+        pipeline.elastic_repo.search.return_value = [hits]
+        pipeline.ioc_repo.is_empty.return_value = False
+        pipeline.ioc_repo.is_ready_for_extraction.return_value = False
+
+        with patch("greedybear.cronjobs.extraction.pipeline.update_activity_buckets_from_hits") as mock_update_activity:
+            pipeline.execute()
+
+        mock_update_activity.assert_not_called()
         mock_factory.return_value.get_strategy.assert_not_called()
 
 

--- a/tests/greedybear/cronjobs/test_extraction_pipeline_edge_cases.py
+++ b/tests/greedybear/cronjobs/test_extraction_pipeline_edge_cases.py
@@ -60,10 +60,10 @@ class TestEdgeCases(E2ETestCase):
         # Scoring should be called with successful IOCs
         mock_scores.return_value.score_only.assert_called_once()
 
-    @patch("greedybear.cronjobs.extraction.pipeline.update_activity_buckets_from_hits", return_value=0)
+    @patch("greedybear.cronjobs.extraction.pipeline.BucketUpdater")
     @patch("greedybear.cronjobs.extraction.pipeline.UpdateScores")
     @patch("greedybear.cronjobs.extraction.pipeline.ExtractionStrategyFactory")
-    def test_activity_bucket_update_failure_does_not_abort_extraction(self, mock_factory, mock_scores, _mock_update_activity):
+    def test_activity_bucket_update_failure_does_not_abort_extraction(self, mock_factory, mock_scores, mock_bucket_updater_cls):
         pipeline = self._create_pipeline_with_real_factory()
         pipeline.log = MagicMock()
 
@@ -73,6 +73,9 @@ class TestEdgeCases(E2ETestCase):
         pipeline.elastic_repo.search.return_value = [hits]
         pipeline.ioc_repo.is_empty.return_value = False
         pipeline.ioc_repo.is_ready_for_extraction.return_value = True
+
+        bucket_updater = mock_bucket_updater_cls.return_value
+        bucket_updater.total_update_count = 0
 
         mock_success = MagicMock()
         mock_success.ioc_records = [self._create_mock_ioc("2.2.2.2")]
@@ -83,13 +86,14 @@ class TestEdgeCases(E2ETestCase):
         self.assertEqual(result, 1)
         mock_success.extract_from_hits.assert_called_once()
         mock_scores.return_value.score_only.assert_called_once()
-        _mock_update_activity.assert_called_once()
+        bucket_updater.collect_hits.assert_called_once()
+        bucket_updater.update.assert_called_once()
 
     @patch("greedybear.cronjobs.extraction.pipeline.caches")
-    @patch("greedybear.cronjobs.extraction.pipeline.update_activity_buckets_from_hits", return_value=2)
+    @patch("greedybear.cronjobs.extraction.pipeline.BucketUpdater")
     @patch("greedybear.cronjobs.extraction.pipeline.UpdateScores")
     @patch("greedybear.cronjobs.extraction.pipeline.ExtractionStrategyFactory")
-    def test_bucket_updates_invalidate_trending_cache(self, mock_factory, mock_scores, _mock_update_activity, mock_caches):
+    def test_bucket_updates_invalidate_trending_cache(self, mock_factory, mock_scores, mock_bucket_updater_cls, mock_caches):
         pipeline = self._create_pipeline_with_real_factory()
         pipeline.log = MagicMock()
 
@@ -99,6 +103,9 @@ class TestEdgeCases(E2ETestCase):
         pipeline.elastic_repo.search.return_value = [hits]
         pipeline.ioc_repo.is_empty.return_value = False
         pipeline.ioc_repo.is_ready_for_extraction.return_value = True
+
+        bucket_updater = mock_bucket_updater_cls.return_value
+        bucket_updater.total_update_count = 2
 
         mock_strategy = MagicMock()
         mock_strategy.ioc_records = []
@@ -110,15 +117,16 @@ class TestEdgeCases(E2ETestCase):
         result = pipeline.execute()
 
         self.assertEqual(result, 0)
-        _mock_update_activity.assert_called_once()
+        bucket_updater.collect_hits.assert_called_once()
+        bucket_updater.update.assert_called_once()
         shared_cache.incr.assert_called_once_with("trending_feeds_version")
         mock_scores.return_value.score_only.assert_not_called()
 
     @patch("greedybear.cronjobs.extraction.pipeline.caches")
-    @patch("greedybear.cronjobs.extraction.pipeline.update_activity_buckets_from_hits", return_value=0)
+    @patch("greedybear.cronjobs.extraction.pipeline.BucketUpdater")
     @patch("greedybear.cronjobs.extraction.pipeline.UpdateScores")
     @patch("greedybear.cronjobs.extraction.pipeline.ExtractionStrategyFactory")
-    def test_disabled_honeypot_hits_do_not_update_activity_buckets(self, mock_factory, mock_scores, mock_update_activity, mock_caches):
+    def test_disabled_honeypot_hits_do_not_update_activity_buckets(self, mock_factory, mock_scores, mock_bucket_updater_cls, mock_caches):
         """Hits from honeypots not ready for extraction must be excluded from bucket updates."""
         pipeline = self._create_pipeline_with_real_factory()
         pipeline.log = MagicMock()
@@ -132,6 +140,9 @@ class TestEdgeCases(E2ETestCase):
         pipeline.ioc_repo.is_empty.return_value = False
         pipeline.ioc_repo.is_ready_for_extraction.side_effect = lambda hp: hp == "EnabledHoneypot"
 
+        bucket_updater = mock_bucket_updater_cls.return_value
+        bucket_updater.total_update_count = 0
+
         mock_strategy = MagicMock()
         mock_strategy.ioc_records = []
         mock_factory.return_value.get_strategy.return_value = mock_strategy
@@ -141,17 +152,19 @@ class TestEdgeCases(E2ETestCase):
 
         pipeline.execute()
 
-        # update_activity_buckets_from_hits must be called exactly once, only with hits from the enabled honeypot.
-        mock_update_activity.assert_called_once()
-        passed_hits = list(mock_update_activity.call_args.args[0])
+        # collect_hits must be called exactly once, only with hits from the enabled honeypot.
+        bucket_updater.collect_hits.assert_called_once()
+        passed_hits = list(bucket_updater.collect_hits.call_args.args[0])
         self.assertEqual(len(passed_hits), 1)
         self.assertEqual(passed_hits[0]["type"], "EnabledHoneypot")
         self.assertEqual(passed_hits[0]["src_ip"], "2.2.2.2")
 
+    @patch("greedybear.cronjobs.extraction.pipeline.caches")
+    @patch("greedybear.cronjobs.extraction.pipeline.BucketUpdater")
     @patch("greedybear.cronjobs.extraction.pipeline.UpdateScores")
     @patch("greedybear.cronjobs.extraction.pipeline.ExtractionStrategyFactory")
-    def test_all_honeypots_disabled_skips_bucket_updates_entirely(self, mock_factory, mock_scores):
-        """When every honeypot in a chunk is disabled, activity buckets are never touched."""
+    def test_all_honeypots_disabled_skips_bucket_updates_entirely(self, mock_factory, mock_scores, mock_bucket_updater_cls, mock_caches):
+        """When every honeypot in a chunk is disabled, no hits are collected and the trending cache is not invalidated."""
         pipeline = self._create_pipeline_with_real_factory()
         pipeline.log = MagicMock()
 
@@ -163,11 +176,17 @@ class TestEdgeCases(E2ETestCase):
         pipeline.ioc_repo.is_empty.return_value = False
         pipeline.ioc_repo.is_ready_for_extraction.return_value = False
 
-        with patch("greedybear.cronjobs.extraction.pipeline.update_activity_buckets_from_hits") as mock_update_activity:
-            pipeline.execute()
+        bucket_updater = mock_bucket_updater_cls.return_value
+        bucket_updater.total_update_count = 0
 
-        mock_update_activity.assert_not_called()
+        shared_cache = MagicMock()
+        mock_caches.__getitem__.return_value = shared_cache
+
+        pipeline.execute()
+
+        bucket_updater.collect_hits.assert_not_called()
         mock_factory.return_value.get_strategy.assert_not_called()
+        shared_cache.incr.assert_not_called()
 
 
 class TestLargeBatches(E2ETestCase):

--- a/tests/greedybear/cronjobs/test_trending.py
+++ b/tests/greedybear/cronjobs/test_trending.py
@@ -2,7 +2,6 @@ from datetime import datetime
 from unittest.mock import patch
 
 from django.test import SimpleTestCase, override_settings
-from elasticsearch.dsl.response import Hit
 
 from greedybear.cronjobs.bucket_cleanup import TrendingBucketCleanupCron
 from greedybear.cronjobs.bucket_utils import update_activity_buckets_from_hits
@@ -72,9 +71,9 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
 
         unique_keys = update_activity_buckets_from_hits(
             [
-                Hit({"_source": {"src_ip": "1.1.1.1", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "1.1.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:50:00"}}),
-                Hit({"_source": {"src_ip": "2.2.2.2", "type": "Heralding", "@timestamp": "2026-03-20T09:10:00"}}),
+                {"src_ip": "1.1.1.1", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "1.1.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:50:00"},
+                {"src_ip": "2.2.2.2", "type": "Heralding", "@timestamp": "2026-03-20T09:10:00"},
             ]
         )
 
@@ -97,10 +96,10 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
     def test_invalid_hits_are_ignored(self):
         unique_keys = update_activity_buckets_from_hits(
             [
-                Hit({"_source": {"src_ip": "", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "999.999.999.999", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "3.3.3.3", "type": "", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "3.3.3.3", "type": "cowrie"}}),
+                {"src_ip": "", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "999.999.999.999", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "3.3.3.3", "type": "", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "3.3.3.3", "type": "cowrie"},
             ]
         )
 
@@ -110,7 +109,7 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
     def test_invalid_timestamp_is_ignored(self):
         unique_keys = update_activity_buckets_from_hits(
             [
-                Hit({"_source": {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "not-a-timestamp"}}),
+                {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "not-a-timestamp"},
             ]
         )
         self.assertEqual(unique_keys, 0)
@@ -119,12 +118,12 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
     def test_non_global_ip_hits_are_ignored(self):
         unique_keys = update_activity_buckets_from_hits(
             [
-                Hit({"_source": {"src_ip": "10.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "127.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "224.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "169.254.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "240.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
-                Hit({"_source": {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                {"src_ip": "10.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "127.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "224.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "169.254.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "240.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
+                {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
             ]
         )
 
@@ -135,7 +134,7 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
     def test_global_ipv6_hit_is_counted(self):
         unique_keys = update_activity_buckets_from_hits(
             [
-                Hit({"_source": {"src_ip": "2001:4860:4860::8888", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"}}),
+                {"src_ip": "2001:4860:4860::8888", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"},
             ]
         )
         self.assertEqual(unique_keys, 1)
@@ -167,7 +166,7 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
 
     @patch("greedybear.cronjobs.bucket_utils.TrendingBucketRepository.upsert_bucket_counts", side_effect=Exception("db down"))
     def test_upsert_failure_returns_zero(self, mock_upsert):
-        unique_keys = update_activity_buckets_from_hits([Hit({"_source": {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}})])
+        unique_keys = update_activity_buckets_from_hits([{"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}])
         self.assertEqual(unique_keys, 0)
         mock_upsert.assert_called_once()
 

--- a/tests/greedybear/cronjobs/test_trending.py
+++ b/tests/greedybear/cronjobs/test_trending.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 from django.test import SimpleTestCase, override_settings
 
 from greedybear.cronjobs.bucket_cleanup import TrendingBucketCleanupCron
-from greedybear.cronjobs.bucket_utils import update_activity_buckets_from_hits
+from greedybear.cronjobs.extraction.bucket_updater import BucketUpdater
 from greedybear.cronjobs.repositories.trending_bucket import TrendingBucketRepository
 from greedybear.cronjobs.trending import (
     attacker_sort_tuple,
@@ -69,13 +69,15 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
             interaction_count=3,
         )
 
-        unique_keys = update_activity_buckets_from_hits(
+        bu = BucketUpdater()
+        bu.collect_hits(
             [
                 {"src_ip": "1.1.1.1", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"},
                 {"src_ip": "1.1.1.1", "type": "cowrie", "@timestamp": "2026-03-20T09:50:00"},
                 {"src_ip": "2.2.2.2", "type": "Heralding", "@timestamp": "2026-03-20T09:10:00"},
             ]
         )
+        unique_keys = bu.update()
 
         self.assertEqual(unique_keys, 2)
 
@@ -94,7 +96,8 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
         self.assertEqual(created_bucket.interaction_count, 1)
 
     def test_invalid_hits_are_ignored(self):
-        unique_keys = update_activity_buckets_from_hits(
+        bu = BucketUpdater()
+        bu.collect_hits(
             [
                 {"src_ip": "", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
                 {"src_ip": "999.999.999.999", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
@@ -102,21 +105,26 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
                 {"src_ip": "3.3.3.3", "type": "cowrie"},
             ]
         )
+        unique_keys = bu.update()
 
         self.assertEqual(unique_keys, 0)
         self.assertEqual(AttackerActivityBucket.objects.count(), 0)
 
     def test_invalid_timestamp_is_ignored(self):
-        unique_keys = update_activity_buckets_from_hits(
+        bu = BucketUpdater()
+        bu.collect_hits(
             [
                 {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "not-a-timestamp"},
             ]
         )
+        unique_keys = bu.update()
+
         self.assertEqual(unique_keys, 0)
         self.assertEqual(AttackerActivityBucket.objects.count(), 0)
 
     def test_non_global_ip_hits_are_ignored(self):
-        unique_keys = update_activity_buckets_from_hits(
+        bu = BucketUpdater()
+        bu.collect_hits(
             [
                 {"src_ip": "10.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
                 {"src_ip": "127.0.0.1", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
@@ -126,17 +134,21 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
                 {"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"},
             ]
         )
+        unique_keys = bu.update()
 
         self.assertEqual(unique_keys, 1)
         self.assertEqual(AttackerActivityBucket.objects.count(), 1)
         self.assertTrue(AttackerActivityBucket.objects.filter(attacker_ip="8.8.8.8").exists())
 
     def test_global_ipv6_hit_is_counted(self):
-        unique_keys = update_activity_buckets_from_hits(
+        bu = BucketUpdater()
+        bu.collect_hits(
             [
                 {"src_ip": "2001:4860:4860::8888", "type": "Cowrie", "@timestamp": "2026-03-20T09:15:00"},
             ]
         )
+        unique_keys = bu.update()
+
         self.assertEqual(unique_keys, 1)
         self.assertTrue(
             AttackerActivityBucket.objects.filter(
@@ -164,9 +176,11 @@ class UpdateActivityBucketsFromHitsTestCase(CustomTestCase):
         self.assertEqual(inserted, 5)
         self.assertEqual(mock_cursor.execute.call_count, 3)
 
-    @patch("greedybear.cronjobs.bucket_utils.TrendingBucketRepository.upsert_bucket_counts", side_effect=Exception("db down"))
+    @patch("greedybear.cronjobs.extraction.bucket_updater.TrendingBucketRepository.upsert_bucket_counts", side_effect=Exception("db down"))
     def test_upsert_failure_returns_zero(self, mock_upsert):
-        unique_keys = update_activity_buckets_from_hits([{"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}])
+        bu = BucketUpdater()
+        bu.collect_hits([{"src_ip": "8.8.8.8", "type": "cowrie", "@timestamp": "2026-03-20T09:15:00"}])
+        unique_keys = bu.update()
         self.assertEqual(unique_keys, 0)
         mock_upsert.assert_called_once()
 


### PR DESCRIPTION
# Description

This moves the bucket update call inside the per-honeypot loop and behind the is_ready_for_extraction gate, so hits from disabled honeypots no longer tracked. Also refactors the former `bucket_utils` module into a stateful `BucketUpdater` class under and adds a Django admin view for AttackerActivityBucket.

### Related issues
Closes #1275

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
