### PR TITLE
Fix include_similar=false being treated as enabled in command_sequence endpoint. Closes #1270

### DIFF
--- a/api/views/command_sequence.py
+++ b/api/views/command_sequence.py
@@ -45,7 +45,7 @@ def command_sequence_view(request):
         Http404: If the requested resource is not found
     """
     observable = request.query_params.get("query")
-    include_similar = request.query_params.get("include_similar") is not None
+    include_similar = request.query_params.get("include_similar", "false").lower() == "true"
     logger.info(f"Command Sequence view requested by {request.user} for {observable}")
 
     if not observable:

--- a/tests/api/views/test_command_sequence_view.py
+++ b/tests/api/views/test_command_sequence_view.py
@@ -54,6 +54,43 @@ class CommandSequenceViewTestCase(CustomTestCase):
             f"include_similar lost base results: {base_executed_by - similar_executed_by}",
         )
 
+    # # # # # Parameter Validation Tests # # # # #
+    def test_include_similar_false_value(self):
+        """Test that include_similar=false behaves like missing include_similar."""
+        base_response = self.client.get("/api/command_sequence?query=140.246.171.141")
+        self.assertEqual(base_response.status_code, 200)
+
+        false_response = self.client.get("/api/command_sequence?query=140.246.171.141&include_similar=false")
+        self.assertEqual(false_response.status_code, 200)
+
+        self.assertEqual(base_response.data["executed_by"], false_response.data["executed_by"])
+
+    def test_include_similar_true_expands_results(self):
+        """Test that include_similar=true returns a superset (or equal set) of base results."""
+        base_response = self.client.get("/api/command_sequence?query=140.246.171.141")
+        self.assertEqual(base_response.status_code, 200)
+        base_executed_by = set(base_response.data["executed_by"])
+
+        true_response = self.client.get("/api/command_sequence?query=140.246.171.141&include_similar=true")
+        self.assertEqual(true_response.status_code, 200)
+        true_executed_by = set(true_response.data["executed_by"])
+
+        self.assertTrue(base_executed_by.issubset(true_executed_by))
+
+    def test_case_insensitive_boolean_parameters(self):
+        """Test that boolean parameters accept various case formats."""
+        lower_true_response = self.client.get("/api/command_sequence?query=140.246.171.141&include_similar=true")
+        self.assertEqual(lower_true_response.status_code, 200)
+
+        upper_true_response = self.client.get("/api/command_sequence?query=140.246.171.141&include_similar=TRUE")
+        self.assertEqual(upper_true_response.status_code, 200)
+
+        title_true_response = self.client.get("/api/command_sequence?query=140.246.171.141&include_similar=True")
+        self.assertEqual(title_true_response.status_code, 200)
+
+        self.assertEqual(lower_true_response.data["executed_by"], upper_true_response.data["executed_by"])
+        self.assertEqual(lower_true_response.data["executed_by"], title_true_response.data["executed_by"])
+
     def test_include_similar_with_unclustered_sequences(self):
         """Test that include_similar still returns results when sequences have no cluster."""
         # Remove cluster from the command sequence


### PR DESCRIPTION
This PR fixes a bug in the `command_sequence` endpoint where the `include_similar` parameter was evaluated based on its presence rather than its value. Previously, requests like `?include_similar=false` would incorrectly trigger similar sequence expansion.

The parsing logic has been updated to explicitly check for a truthy value, aligning behavior with `cowrie_session.py`.

Additional tests were added to cover:
- omitted parameter
- `include_similar=false`
- `include_similar=true`
- case-insensitive values (`TRUE`, `True`)

---

### Related issues

Closes #1270

---

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

---

## Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request.
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

---

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior described in the docs (not applicable).
- [x] Linter (`Ruff`) gave 0 errors.
- [x] I have added tests for the bug I solved.
- [x] All the tests gave 0 errors.

---

### GUI changes

(Not applicable)