### PR TITLE
Expose credential_count in IOC feeds and enable filtering by credential usage . Closes #1294

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -132,6 +132,8 @@ class FeedsRequestSerializer(serializers.Serializer):
     ioc_type = serializers.ChoiceField(choices=["ip", "domain", "all"])
     max_age = serializers.IntegerField(min_value=1)
     min_days_seen = serializers.IntegerField(min_value=1)
+    min_credential_count = serializers.IntegerField(required=False, min_value=0)
+    max_credential_count = serializers.IntegerField(required=False, min_value=0)
     include_reputation = serializers.ListField(child=serializers.CharField(max_length=120))
     exclude_reputation = serializers.ListField(child=serializers.CharField(max_length=120))
     feed_size = serializers.IntegerField(min_value=1)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -132,7 +132,7 @@ class FeedsRequestSerializer(serializers.Serializer):
     ioc_type = serializers.ChoiceField(choices=["ip", "domain", "all"])
     max_age = serializers.IntegerField(min_value=1)
     min_days_seen = serializers.IntegerField(min_value=1)
-    min_credential_count = serializers.IntegerField(required=False, min_value=0)
+    min_credential_count = serializers.IntegerField(required=False, min_value=1)
     max_credential_count = serializers.IntegerField(required=False, min_value=0)
     include_reputation = serializers.ListField(child=serializers.CharField(max_length=120))
     exclude_reputation = serializers.ListField(child=serializers.CharField(max_length=120))
@@ -168,6 +168,13 @@ class FeedsRequestSerializer(serializers.Serializer):
     def validate_ordering(self, ordering):
         logger.debug(f"FeedsRequestSerializer - validation ordering: '{ordering}'")
         return ordering_validation(ordering)
+
+    def validate(self, data):
+        min_cc = data.get("min_credential_count")
+        max_cc = data.get("max_credential_count")
+        if min_cc is not None and max_cc is not None and min_cc > max_cc:
+            raise serializers.ValidationError("min_credential_count must be less than or equal to max_credential_count")
+        return data
 
 
 class ASNFeedsOrderingSerializer(FeedsRequestSerializer):

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -154,6 +154,7 @@ def feeds_advanced(request):
         tag_key=request.query_params.get("tag_key", "").strip(),
         tag_value=request.query_params.get("tag_value", "").strip(),
         include_sensors=True,
+        include_credential_count=True,
     )
     if paginate:
         paginator = CustomPageNumberPagination()

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -127,6 +127,8 @@ def feeds_advanced(request):
         attack_type (str): Type of attack to filter. (supported: `scanner`, `payload_request`, `all`; default: `all`)
         max_age (int): Maximum number of days since last occurrence. E.g. an IOC that was last seen 4 days ago is excluded by default. (default: 3)
         min_days_seen (int): Minimum number of days on which an IOC must have been seen. (default: 1)
+        min_credential_count (int, optional): Filter IOCs with at least this many distinct credentials. (default: no filter)
+        max_credential_count (int, optional): Filter IOCs with at most this many distinct credentials. (default: no filter)
         include_reputation (str): `;`-separated list of reputation values to include, e.g. `known attacker` or `known attacker;` to include IOCs without reputation. (default: include all)
         exclude_reputation (str): `;`-separated list of reputation values to exclude, e.g. `mass scanner` or `mass scanner;bot, crawler`. (default: exclude none)
         feed_size (int): Number of IOC items to return. (default: 5000)

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -108,6 +108,14 @@ class FeedRequestParams:
         self.start_date = query_params.get("start_date")
         self.end_date = query_params.get("end_date")
         self.country_code = query_params.get("country_code")
+        self.min_credential_count = self._safe_int(query_params.get("min_credential_count"))
+        self.max_credential_count = self._safe_int(query_params.get("max_credential_count"))
+
+    def _safe_int(self, value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     def apply_default_filters(self, query_params):
         if not query_params:
@@ -232,7 +240,19 @@ def get_queryset(
     if tag_value:
         query_dict["tags__value__icontains"] = tag_value[:256]  # Truncate to Tag.value max_length
 
-    iocs = IOC.objects.filter(**query_dict).exclude(ip_reputation__in=feed_params.exclude_reputation).annotate(value=F("name")).distinct()
+    iocs = (
+        IOC.objects.filter(**query_dict)
+        .annotate(credential_count=Count("credentials", distinct=True))
+        .exclude(ip_reputation__in=feed_params.exclude_reputation)
+        .annotate(value=F("name"))
+        .distinct()
+    )
+
+    if feed_params.min_credential_count is not None:
+        iocs = iocs.filter(credential_count__gte=feed_params.min_credential_count)
+
+    if feed_params.max_credential_count is not None:
+        iocs = iocs.filter(credential_count__lte=feed_params.max_credential_count)
 
     # apply feed type filter as union;
     if "all" not in feed_params.feed_types:
@@ -329,6 +349,7 @@ def feeds_response(request=None, iocs=None, feed_params=None, valid_feed_types=N
                 "first_seen",
                 "last_seen",
                 "attack_count",
+                "credential_count",
                 "interaction_count",
                 "scanner",
                 "payload_request",
@@ -358,11 +379,13 @@ def feeds_response(request=None, iocs=None, feed_params=None, valid_feed_types=N
             if isinstance(iocs, list):
                 has_tags_annotation = bool(iocs) and hasattr(iocs[0], "tags_json")
                 has_sensors_annotation = include_sensors and bool(iocs) and hasattr(iocs[0], "sensors_json")
+                has_credential_count = bool(iocs) and hasattr(iocs[0], "credential_count")
             else:
                 has_tags_annotation = "tags_json" in getattr(iocs, "query", type("", (), {"annotations": {}})()).annotations
                 has_sensors_annotation = include_sensors and "sensors_json" in getattr(iocs, "query", type("", (), {"annotations": {}})()).annotations
-
+                has_credential_count = "credential_count" in getattr(iocs, "query", type("", (), {"annotations": {}})()).annotations
             required_fields = tuple(("tags_json" if f == "tags" else f) for f in required_fields if f != "tags" or has_tags_annotation)
+            required_fields = tuple(f for f in required_fields if f != "credential_count" or has_credential_count)
             if has_sensors_annotation:
                 required_fields = required_fields + ("sensors_json",)
 

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -108,14 +108,8 @@ class FeedRequestParams:
         self.start_date = query_params.get("start_date")
         self.end_date = query_params.get("end_date")
         self.country_code = query_params.get("country_code")
-        self.min_credential_count = self._safe_int(query_params.get("min_credential_count"))
-        self.max_credential_count = self._safe_int(query_params.get("max_credential_count"))
-
-    def _safe_int(self, value):
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            return None
+        self.min_credential_count = query_params.get("min_credential_count")
+        self.max_credential_count = query_params.get("max_credential_count")
 
     def apply_default_filters(self, query_params):
         if not query_params:
@@ -162,7 +156,15 @@ def get_valid_feed_types() -> frozenset[str]:
 
 
 def get_queryset(
-    request, feed_params, valid_feed_types, is_aggregated=False, serializer_class=FeedsRequestSerializer, tag_key="", tag_value="", include_sensors=False
+    request,
+    feed_params,
+    valid_feed_types,
+    is_aggregated=False,
+    serializer_class=FeedsRequestSerializer,
+    tag_key="",
+    tag_value="",
+    include_sensors=False,
+    include_credential_count=False,
 ):
     """
     Build a queryset to filter IOC data based on the request parameters.
@@ -184,7 +186,8 @@ def get_queryset(
         tag_value (str, optional): Filter IOCs by tag value (case-insensitive substring). Only passed from feeds_advanced.
         include_sensors (bool, optional): If True, annotates sensors_json for each IOC.
             Only passed from authenticated views like feeds_advanced. Default: False.
-
+        include_credential_count (bool, optional): If True, annotates credential Count for each IOC.
+            Only passed from authenticated views like feeds_advanced. Default: False.
     Returns:
         QuerySet: The filtered queryset of IOC data.
     """
@@ -240,19 +243,18 @@ def get_queryset(
     if tag_value:
         query_dict["tags__value__icontains"] = tag_value[:256]  # Truncate to Tag.value max_length
 
-    iocs = (
-        IOC.objects.filter(**query_dict)
-        .annotate(credential_count=Count("credentials", distinct=True))
-        .exclude(ip_reputation__in=feed_params.exclude_reputation)
-        .annotate(value=F("name"))
-        .distinct()
-    )
+    iocs = IOC.objects.filter(**query_dict).exclude(ip_reputation__in=feed_params.exclude_reputation).annotate(value=F("name")).distinct()
 
-    if feed_params.min_credential_count is not None:
-        iocs = iocs.filter(credential_count__gte=feed_params.min_credential_count)
-
-    if feed_params.max_credential_count is not None:
-        iocs = iocs.filter(credential_count__lte=feed_params.max_credential_count)
+    # credential count filtering is only available on the advanced feed
+    if include_credential_count:
+        min_credential_count = serializer.validated_data.get("min_credential_count")
+        max_credential_count = serializer.validated_data.get("max_credential_count")
+        if min_credential_count is not None or max_credential_count is not None:
+            iocs = iocs.annotate(credential_count=Count("credentials", distinct=True))
+            if min_credential_count is not None:
+                iocs = iocs.filter(credential_count__gte=min_credential_count)
+            if max_credential_count is not None:
+                iocs = iocs.filter(credential_count__lte=max_credential_count)
 
     # apply feed type filter as union;
     if "all" not in feed_params.feed_types:

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -247,14 +247,13 @@ def get_queryset(
 
     # credential count filtering is only available on the advanced feed
     if include_credential_count:
+        iocs = iocs.annotate(credential_count=Count("credentials", distinct=True))
         min_credential_count = serializer.validated_data.get("min_credential_count")
         max_credential_count = serializer.validated_data.get("max_credential_count")
-        if min_credential_count is not None or max_credential_count is not None:
-            iocs = iocs.annotate(credential_count=Count("credentials", distinct=True))
-            if min_credential_count is not None:
-                iocs = iocs.filter(credential_count__gte=min_credential_count)
-            if max_credential_count is not None:
-                iocs = iocs.filter(credential_count__lte=max_credential_count)
+        if min_credential_count is not None:
+            iocs = iocs.filter(credential_count__gte=min_credential_count)
+        if max_credential_count is not None:
+            iocs = iocs.filter(credential_count__lte=max_credential_count)
 
     # apply feed type filter as union;
     if "all" not in feed_params.feed_types:

--- a/tests/api/views/test_feeds_advanced_view.py
+++ b/tests/api/views/test_feeds_advanced_view.py
@@ -8,7 +8,7 @@ from django.core.cache import cache
 from rest_framework.test import APIClient
 
 from api.throttles import SharedFeedRateThrottle
-from greedybear.models import IOC, AutonomousSystem, IocType, Sensor, ShareToken
+from greedybear.models import IOC, AutonomousSystem, Credential, IocType, Sensor, ShareToken
 from tests import CustomTestCase
 
 
@@ -139,6 +139,45 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         iocs = response.json()["iocs"]
         for ioc in iocs:
             self.assertNotIn("sensors", ioc)
+
+    def test_min_credential_count_filter(self):
+        """IOCs with fewer credentials than min_credential_count are excluded."""
+        cred1 = Credential.objects.create(username="admin", password="admin")
+        cred2 = Credential.objects.create(username="root", password="1234")
+        self.ioc.credentials.add(cred1, cred2)
+
+        response = self.client.get("/api/feeds/advanced/?min_credential_count=2")
+        self.assertEqual(response.status_code, 200)
+        iocs = response.json()["iocs"]
+        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+        self.assertIsNotNone(target_ioc)
+        self.assertGreaterEqual(target_ioc["credential_count"], 2)
+
+    def test_max_credential_count_filter(self):
+        """IOCs with more credentials than max_credential_count are excluded."""
+        cred1 = Credential.objects.create(username="admin", password="admin")
+        cred2 = Credential.objects.create(username="root", password="1234")
+        self.ioc.credentials.add(cred1, cred2)
+
+        response = self.client.get("/api/feeds/advanced/?max_credential_count=1")
+        self.assertEqual(response.status_code, 200)
+        iocs = response.json()["iocs"]
+        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+        # self.ioc has 2 credentials so it should be excluded
+        self.assertIsNone(target_ioc)
+
+    def test_credential_count_in_response(self):
+        """credential_count field is present in JSON response."""
+        cred1 = Credential.objects.create(username="admin", password="admin")
+        self.ioc.credentials.add(cred1)
+
+        response = self.client.get("/api/feeds/advanced/")
+        self.assertEqual(response.status_code, 200)
+        iocs = response.json()["iocs"]
+        target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)
+        self.assertIsNotNone(target_ioc)
+        self.assertIn("credential_count", target_ioc)
+        self.assertEqual(target_ioc["credential_count"], 1)
 
 
 class FeedsEnhancementsTestCase(CustomTestCase):

--- a/tests/api/views/test_feeds_advanced_view.py
+++ b/tests/api/views/test_feeds_advanced_view.py
@@ -167,11 +167,10 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         self.assertIsNone(target_ioc)
 
     def test_credential_count_in_response(self):
-        """credential_count field is present in JSON response."""
+        """credential_count field is present in JSON response when filtering by credential count."""
         cred1 = Credential.objects.create(username="admin", password="admin")
         self.ioc.credentials.add(cred1)
-
-        response = self.client.get("/api/feeds/advanced/")
+        response = self.client.get("/api/feeds/advanced/?min_credential_count=1")
         self.assertEqual(response.status_code, 200)
         iocs = response.json()["iocs"]
         target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)

--- a/tests/api/views/test_feeds_advanced_view.py
+++ b/tests/api/views/test_feeds_advanced_view.py
@@ -115,6 +115,11 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         self.assertIsNotNone(target_ioc)
         self.assertEqual(target_ioc["attacker_country_code"], "NP")
 
+    def test_400_invalid_credential_count_range(self):
+        """min_credential_count greater than max_credential_count returns 400."""
+        response = self.client.get("/api/feeds/advanced/?min_credential_count=10&max_credential_count=5")
+        self.assertEqual(response.status_code, 400)
+
     def test_feeds_advanced_includes_sensors(self):
         """Sensors field appears in feeds_advanced response for authenticated users."""
         sensor = Sensor.objects.create(address="10.0.0.1", label="test-sensor")
@@ -170,7 +175,7 @@ class FeedsAdvancedViewTestCase(CustomTestCase):
         """credential_count field is present in JSON response when filtering by credential count."""
         cred1 = Credential.objects.create(username="admin", password="admin")
         self.ioc.credentials.add(cred1)
-        response = self.client.get("/api/feeds/advanced/?min_credential_count=1")
+        response = self.client.get("/api/feeds/advanced/")
         self.assertEqual(response.status_code, 200)
         iocs = response.json()["iocs"]
         target_ioc = next((i for i in iocs if i["value"] == self.ioc.name), None)


### PR DESCRIPTION
# Description

This pr will provide  credential-level visibility into IOC feeds by exposing a computed `credential_count` field and adding filtering support via `min_credential_count` and `max_credential_count` query parameters.

1. Queryset enhancement
- Annotate IOC queryset with:
  - `credntial_count = Count("credentials", distinct=True)`
- Enables per-IOC credential activity tracking.

2. Filtering support
- Added query parameters:
  - `min_credential_count`
  - `max_credential_count`
- Allows filtering IOCs based on credential interaction volume.

3. API response update
- credential_count is now included in JSON feed response.


### Related issues
Closes: #1294
related: #1098

Please add related issues: the issues you are trying to solve as well as other issues that are important in the context of this pull request.

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [ ] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
