### PR TITLE
Enhancement: bulk prefetch IOCs before processing to eliminate per-IOC SELECT queries. Closes #1241

### DIFF
--- a/greedybear/cronjobs/extraction/ioc_processor.py
+++ b/greedybear/cronjobs/extraction/ioc_processor.py
@@ -26,6 +26,21 @@ class IocProcessor:
         self.ioc_repo = ioc_repo
         self.sensor_repo = sensor_repo
         self._whatsmyip_domains = set(WhatsMyIPDomain.objects.values_list("domain", flat=True))
+        self._ioc_cache: dict[str, IOC] = {}
+
+    def prefetch_iocs(self, names: list[str]) -> None:
+        """
+        Bulk prefetch existing IOC records into the cache.
+        Eliminates per-IOC SELECT queries in add_ioc() by loading all
+        known IOCs for the current batch in a single query.
+
+        Args:
+            names: List of IOC names (IPs or domains) to prefetch.
+        """
+        self._ioc_cache = {
+            ioc.name: ioc
+            for ioc in IOC.objects.prefetch_related("honeypots").filter(name__in=names)
+        }
 
     def add_ioc(
         self,
@@ -57,7 +72,7 @@ class IocProcessor:
             self.log.debug(f"not saved {ioc} because it is a whats-my-ip domain")
             return None
 
-        ioc_record = self.ioc_repo.get_ioc_by_name(ioc.name)
+        ioc_record = self._ioc_cache.get(ioc.name) or self.ioc_repo.get_ioc_by_name(ioc.name)
         if ioc_record is None:  # Create
             self.log.debug(f"{ioc} was not seen before - creating a new record")
             ioc_record = self.ioc_repo.save(ioc)
@@ -77,6 +92,7 @@ class IocProcessor:
         ioc_record.payload_request = ioc_record.payload_request or (attack_type == PAYLOAD_REQUEST)
 
         self.ioc_repo.save(ioc_record)
+        self._ioc_cache[ioc_record.name] = ioc_record
         return ioc_record
 
     def _merge_iocs(self, existing: IOC, new: IOC) -> IOC:

--- a/greedybear/cronjobs/extraction/ioc_processor.py
+++ b/greedybear/cronjobs/extraction/ioc_processor.py
@@ -37,10 +37,7 @@ class IocProcessor:
         Args:
             names: List of IOC names (IPs or domains) to prefetch.
         """
-        self._ioc_cache = {
-            ioc.name: ioc
-            for ioc in IOC.objects.prefetch_related("honeypots").filter(name__in=names)
-        }
+        self._ioc_cache = {ioc.name: ioc for ioc in IOC.objects.prefetch_related("honeypots").filter(name__in=names)}
 
     def add_ioc(
         self,

--- a/greedybear/cronjobs/extraction/strategies/base.py
+++ b/greedybear/cronjobs/extraction/strategies/base.py
@@ -54,8 +54,9 @@ class BaseExtractionStrategy(metaclass=ABCMeta):
             scanner_ip: Scanner IP address.
             hostname: Hostname to link with scanner.
         """
-        scanner_ip_instance = self.ioc_repo.get_ioc_by_name(scanner_ip)
-        hostname_instance = self.ioc_repo.get_ioc_by_name(hostname)
+        ioc_map = {ioc.name: ioc for ioc in self.ioc_records}
+        scanner_ip_instance = ioc_map.get(scanner_ip) or self.ioc_repo.get_ioc_by_name(scanner_ip)
+        hostname_instance = ioc_map.get(hostname) or self.ioc_repo.get_ioc_by_name(hostname)
 
         if not scanner_ip_instance or not hostname_instance:
             self.log.warning(

--- a/greedybear/cronjobs/extraction/strategies/cowrie.py
+++ b/greedybear/cronjobs/extraction/strategies/cowrie.py
@@ -95,8 +95,9 @@ class CowrieExtractionStrategy(BaseExtractionStrategy):
         hits_by_ip = defaultdict(list)
         for hit in hits:
             hits_by_ip[hit["src_ip"]].append(hit)
-
-        for ioc in iocs_from_hits(hits):
+        iocs = iocs_from_hits(hits)
+        self.ioc_processor.prefetch_iocs([ioc.name for ioc in iocs])
+        for ioc in iocs:
             self.log.info(f"found IP {ioc.name} by honeypot cowrie")
             ioc_record = self.ioc_processor.add_ioc(ioc, attack_type=SCANNER, honeypot_name="Cowrie")
             if ioc_record:

--- a/greedybear/cronjobs/extraction/strategies/generic.py
+++ b/greedybear/cronjobs/extraction/strategies/generic.py
@@ -21,7 +21,9 @@ class GenericExtractionStrategy(BaseExtractionStrategy):
         Args:
             hits: List of Elasticsearch hits to process.
         """
-        for ioc in iocs_from_hits(hits):
+        iocs = iocs_from_hits(hits)
+        self.ioc_processor.prefetch_iocs([ioc.name for ioc in iocs])
+        for ioc in iocs:
             self.log.info(f"IoC {ioc.name} found by honeypot {self.honeypot}")
             ioc_record = self.ioc_processor.add_ioc(ioc, attack_type=SCANNER, honeypot_name=self.honeypot)
             if ioc_record:

--- a/greedybear/cronjobs/extraction/strategies/heralding.py
+++ b/greedybear/cronjobs/extraction/strategies/heralding.py
@@ -68,7 +68,9 @@ class HeraldingExtractionStrategy(BaseExtractionStrategy):
 
     def _get_scanners(self, hits: list[dict]) -> None:
         """Extract scanner IPs from hits."""
-        for ioc in iocs_from_hits(hits):
+        iocs = iocs_from_hits(hits)
+        self.ioc_processor.prefetch_iocs([ioc.name for ioc in iocs])
+        for ioc in iocs:
             self.log.info(f"found IP {ioc.name} by honeypot {self.honeypot}")
             ioc_record = self.ioc_processor.add_ioc(
                 ioc,

--- a/greedybear/cronjobs/extraction/strategies/tanner.py
+++ b/greedybear/cronjobs/extraction/strategies/tanner.py
@@ -111,7 +111,9 @@ class TannerExtractionStrategy(BaseExtractionStrategy):
 
     def _get_scanners(self, hits: list[dict]) -> None:
         """Extract scanner IPs from hits."""
-        for ioc in iocs_from_hits(hits):
+        iocs = iocs_from_hits(hits)
+        self.ioc_processor.prefetch_iocs([ioc.name for ioc in iocs])
+        for ioc in iocs:
             self.log.info(f"found IP {ioc.name} by honeypot {self.honeypot}")
             ioc_record = self.ioc_processor.add_ioc(ioc, attack_type=SCANNER, honeypot_name=TANNER_HONEYPOT)
             if ioc_record:
@@ -128,9 +130,6 @@ class TannerExtractionStrategy(BaseExtractionStrategy):
         Args:
             hits: List of Elasticsearch hit documents.
         """
-        # Seed cache from IOC records already loaded by _get_scanners to avoid
-        # repeated DB lookups for the same scanner IP across many hits.
-        ioc_cache: dict[str, object] = {ioc.name: ioc for ioc in self.ioc_records}
 
         for hit in hits:
             scanner_ip = hit.get("src_ip")
@@ -147,11 +146,9 @@ class TannerExtractionStrategy(BaseExtractionStrategy):
                 continue
 
             # Find the IOC record for this scanner to attach tags.
-            # Use cache to avoid one DB query per hit; fall back to the repo
-            # for IPs not already loaded by _get_scanners.
-            if scanner_ip not in ioc_cache:
-                ioc_cache[scanner_ip] = self.ioc_repo.get_ioc_by_name(scanner_ip)
-            ioc_record = ioc_cache[scanner_ip]
+            # Use the processor-level cache populated by prefetch_iocs() in _get_scanners;
+            # fall back to the repo for IPs not seen in the current batch.
+            ioc_record = self.ioc_processor._ioc_cache.get(scanner_ip) or self.ioc_repo.get_ioc_by_name(scanner_ip)
             if not ioc_record:
                 continue
 

--- a/tests/test_ioc_processor.py
+++ b/tests/test_ioc_processor.py
@@ -6,7 +6,7 @@ from greedybear.cronjobs.extraction.ioc_processor import IocProcessor
 from greedybear.enums import IpReputation
 from greedybear.models import IocType
 
-from . import ExtractionTestCase
+from . import CustomTestCase, ExtractionTestCase
 
 
 class TestAddIoc(ExtractionTestCase):
@@ -186,6 +186,29 @@ class TestAddIoc(ExtractionTestCase):
         result = self.processor.add_ioc(ioc, attack_type=SCANNER)
 
         self.assertIsNotNone(result)
+
+    def test_add_ioc_uses_cache_instead_of_repo(self):
+        """add_ioc() uses _ioc_cache and skips get_ioc_by_name when cache is populated."""
+        self.mock_sensor_repo.cache = {}
+        existing = self._create_mock_ioc(attack_count=5)
+        self.processor._ioc_cache["1.2.3.4"] = existing
+        self.mock_ioc_repo.save.return_value = existing
+
+        self.processor.add_ioc(self._create_mock_ioc(), attack_type=SCANNER)
+
+        self.mock_ioc_repo.get_ioc_by_name.assert_not_called()
+
+    def test_add_ioc_updates_cache_after_save(self):
+        """add_ioc() updates _ioc_cache with saved record."""
+        self.mock_sensor_repo.cache = {}
+        self.mock_ioc_repo.get_ioc_by_name.return_value = None
+        ioc = self._create_mock_ioc()
+        self.mock_ioc_repo.save.return_value = ioc
+
+        self.processor.add_ioc(ioc, attack_type=SCANNER)
+
+        self.assertIn("1.2.3.4", self.processor._ioc_cache)
+        self.assertEqual(self.processor._ioc_cache["1.2.3.4"], ioc)
 
 
 class TestMergeIocs(ExtractionTestCase):
@@ -461,3 +484,27 @@ class TestUpdateDaysSeen(ExtractionTestCase):
 
         self.assertEqual(len(result.days_seen), 1)
         self.assertEqual(result.number_of_days_seen, 1)
+
+class TestPrefetchIocs(CustomTestCase):
+    """Tests for IocProcessor.prefetch_iocs() using real DB objects."""
+
+    def setUp(self):
+        super().setUp()
+        self.mock_sensor_repo = Mock()
+        self.mock_sensor_repo.cache = {}
+        self.mock_ioc_repo = Mock()
+        self.processor = IocProcessor(self.mock_ioc_repo, self.mock_sensor_repo)
+
+    def test_prefetch_populates_cache_with_existing_iocs(self):
+        """prefetch_iocs() loads existing IOCs into cache in one query."""
+        self.processor.prefetch_iocs([self.ioc.name, "nonexistent.ip"])
+
+        self.assertIn(self.ioc.name, self.processor._ioc_cache)
+        self.assertNotIn("nonexistent.ip", self.processor._ioc_cache)
+        self.assertEqual(self.processor._ioc_cache[self.ioc.name].name, self.ioc.name)
+
+    def test_prefetch_empty_list_clears_cache(self):
+        """prefetch_iocs() with empty list results in empty cache."""
+        self.processor._ioc_cache = {"1.2.3.4": Mock()}
+        self.processor.prefetch_iocs([])
+        self.assertEqual(self.processor._ioc_cache, {})

--- a/tests/test_ioc_processor.py
+++ b/tests/test_ioc_processor.py
@@ -485,6 +485,7 @@ class TestUpdateDaysSeen(ExtractionTestCase):
         self.assertEqual(len(result.days_seen), 1)
         self.assertEqual(result.number_of_days_seen, 1)
 
+
 class TestPrefetchIocs(CustomTestCase):
     """Tests for IocProcessor.prefetch_iocs() using real DB objects."""
 


### PR DESCRIPTION
# Description

The extraction pipeline was calling `ioc_repo.get_ioc_by_name()` once per IOC inside `add_ioc()`, so a batch of U unique IPs meant U SELECT queries. On top of that, `_add_fks()` in `BaseExtractionStrategy` was re-fetching IOCs that `add_ioc()` had just processed. Tanner had a manual local `ioc_cache` in `_classify_attacks()` as a partial workaround for the same problem.

This PR fixes all three by introducing a bulk prefetch mechanism in `IocProcessor`:
- Added `_ioc_cache` and `prefetch_iocs()` to `IocProcessor`. Each `_get_scanners()` now bulk-loads all IOCs for the batch in one query before the loop, reducing U SELECTs to 1.
- `add_ioc()` checks the cache first, falls back to the repo only on a miss, and updates the cache after every save.
- `_add_fks()` now builds an in-memory map from `self.ioc_records` instead of making extra DB calls for IOCs already processed.
- Tanner's manual local `ioc_cache` in `_classify_attacks()` is removed and replaced by the processor-level cache.

### Related issues
Closes #1241

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities
- [x] I have read and understood the rules about how to Contribute to this project.
- [x] I chose an appropriate title for the pull request in the form: `Enhancement: bulk prefetch IOCs before processing to eliminate per-IOC SELECT queries. Closes #1241`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests
- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the docs. No user-facing behavior is affected.
- [x] Linter (Ruff) gave 0 errors.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes
No GUI changes in this PR.