### PR TITLE
Fix logout callback. Closes #1282

### DIFF
--- a/frontend/src/components/auth/Logout.jsx
+++ b/frontend/src/components/auth/Logout.jsx
@@ -13,7 +13,7 @@ export default function Logout() {
 
   React.useEffect(() => {
     if (isAuthenticated === AUTHENTICATION_STATUSES.TRUE) {
-      logoutUser();
+      void logoutUser().catch(() => {});
     }
   }, [isAuthenticated, logoutUser]);
 

--- a/frontend/src/stores/useAuthStore.jsx
+++ b/frontend/src/stores/useAuthStore.jsx
@@ -86,16 +86,26 @@ const useAuthStore = create((set, get) => ({
     },
     logoutUser: async () => {
       set({ isAuthenticated: AUTHENTICATION_STATUSES.PENDING });
-      const onLogoutCb = () => {
+      const onLogoutSuccessCb = () => {
         get().reset();
         addToast("Logged out!", null, "info");
+      };
+      const onLogoutErrorCb = (err) => {
+        get().reset();
+        addToast(
+          "Logout request failed. Local session cleared.",
+          err.parsedMsg,
+          "warning",
+          true,
+        );
+        return Promise.reject(err);
       };
       return axios
         .post(LOGOUT_URI, null, {
           certegoUIenableProgressBar: false,
         })
-        .then(onLogoutCb)
-        .catch(onLogoutCb);
+        .then(onLogoutSuccessCb)
+        .catch(onLogoutErrorCb);
     },
     changePassword: async (body) => {
       try {

--- a/frontend/tests/stores/useAuthStore.test.jsx
+++ b/frontend/tests/stores/useAuthStore.test.jsx
@@ -172,8 +172,9 @@ describe("useAuthStore", () => {
       expect(addToast).toHaveBeenCalledWith("Logged out!", null, "info");
     });
 
-    test("still clears state and emits info toast on failure", async () => {
-      axios.post.mockRejectedValue(new Error("network"));
+    test("clears local state, emits warning toast, and rejects on failure", async () => {
+      const err = { parsedMsg: "network" };
+      axios.post.mockRejectedValue(err);
 
       useAuthStore.setState({
         isAuthenticated: AUTHENTICATION_STATUSES.TRUE,
@@ -188,13 +189,18 @@ describe("useAuthStore", () => {
 
       const { logoutUser } = useAuthStore.getState().service;
 
-      await expect(logoutUser()).resolves.toBeUndefined();
+      await expect(logoutUser()).rejects.toEqual(err);
 
       const state = useAuthStore.getState();
       expect(state.isAuthenticated).toBe(AUTHENTICATION_STATUSES.FALSE);
       expect(state.isSuperuser).toBe(false);
       expect(state.user).toEqual(INITIAL_USER);
-      expect(addToast).toHaveBeenCalledWith("Logged out!", null, "info");
+      expect(addToast).toHaveBeenCalledWith(
+        "Logout request failed. Local session cleared.",
+        "network",
+        "warning",
+        true,
+      );
     });
   });
 


### PR DESCRIPTION
# Description
Adds explicit logout error handling in the auth store so failed logout requests still clear local session state and show a warning toast.

### Related issues
#1282

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist
### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.