### PR TITLE
add union by rank to union find implementation in LSH. Closes #1285

### DIFF
--- a/greedybear/cronjobs/commands/lsh.py
+++ b/greedybear/cronjobs/commands/lsh.py
@@ -20,6 +20,7 @@ class UnionFind:
             size (int): Number of elements in the data structure
         """
         self.parents = list(range(size))
+        self.ranks = [0] * size
 
     def find_representative(self, i: int) -> int:
         """
@@ -48,7 +49,17 @@ class UnionFind:
         """
         i_representative = self.find_representative(i)
         j_representative = self.find_representative(j)
-        self.parents[i_representative] = j_representative
+        if i_representative == j_representative:
+            return
+
+        # Attach the shorter tree under the taller one to keep finds efficient (union by rank).
+        if self.ranks[i_representative] < self.ranks[j_representative]:
+            self.parents[i_representative] = j_representative
+        elif self.ranks[i_representative] > self.ranks[j_representative]:
+            self.parents[j_representative] = i_representative
+        else:
+            self.parents[j_representative] = i_representative
+            self.ranks[i_representative] += 1
 
 
 class LSHConnectedComponents:

--- a/tests/test_lsh.py
+++ b/tests/test_lsh.py
@@ -31,17 +31,17 @@ class UnionFindTestCase(SimpleTestCase):
         self.assertEqual(u.find_representative(0), 0)
         self.assertEqual(u.find_representative(2), 2)
 
-    def test_union_by_rank_keeps_higher_rank_root(self):
+    def test_union_by_rank_increments_rank_on_equal_rank_merge(self):
         u = UnionFind(4)
 
         u.union(0, 1)
-        self.assertEqual(u.ranks[u.find_representative(0)], 1)
+        left_root = u.find_representative(0)
+        self.assertEqual(u.ranks[left_root], 1)
 
         u.union(2, 3)
-        self.assertEqual(u.ranks[u.find_representative(2)], 1)
-
-        left_root = u.find_representative(0)
         right_root = u.find_representative(2)
+        self.assertEqual(u.ranks[right_root], 1)
+
         u.union(left_root, right_root)
 
         final_root = u.find_representative(0)
@@ -49,6 +49,23 @@ class UnionFindTestCase(SimpleTestCase):
         self.assertEqual(final_root, u.find_representative(2))
         self.assertEqual(final_root, u.find_representative(3))
         self.assertEqual(u.ranks[final_root], 2)
+
+    def test_union_by_rank_attaches_lower_rank_under_higher_rank(self):
+        u = UnionFind(3)
+
+        u.union(0, 1)
+        higher_rank_root = u.find_representative(0)
+        self.assertEqual(u.ranks[higher_rank_root], 1)
+
+        lower_rank_root = u.find_representative(2)
+        self.assertEqual(u.ranks[lower_rank_root], 0)
+
+        u.union(lower_rank_root, higher_rank_root)
+
+        self.assertEqual(u.find_representative(2), higher_rank_root)
+        self.assertEqual(u.find_representative(0), higher_rank_root)
+        self.assertEqual(u.find_representative(1), higher_rank_root)
+        self.assertEqual(u.ranks[higher_rank_root], 1)
 
 
 class LSHConnectedComponentsTestCase(SimpleTestCase):

--- a/tests/test_lsh.py
+++ b/tests/test_lsh.py
@@ -31,6 +31,25 @@ class UnionFindTestCase(SimpleTestCase):
         self.assertEqual(u.find_representative(0), 0)
         self.assertEqual(u.find_representative(2), 2)
 
+    def test_union_by_rank_keeps_higher_rank_root(self):
+        u = UnionFind(4)
+
+        u.union(0, 1)
+        self.assertEqual(u.ranks[u.find_representative(0)], 1)
+
+        u.union(2, 3)
+        self.assertEqual(u.ranks[u.find_representative(2)], 1)
+
+        left_root = u.find_representative(0)
+        right_root = u.find_representative(2)
+        u.union(left_root, right_root)
+
+        final_root = u.find_representative(0)
+        self.assertEqual(final_root, u.find_representative(1))
+        self.assertEqual(final_root, u.find_representative(2))
+        self.assertEqual(final_root, u.find_representative(3))
+        self.assertEqual(u.ranks[final_root], 2)
+
 
 class LSHConnectedComponentsTestCase(SimpleTestCase):
     def test_get_min_hashes_generates_matching_signatures(self):


### PR DESCRIPTION
# Description
Union by rank attaches shorter trees under the taller one in union operation, to keep finds efficient.
The asymptotic gain is from log n down to alpha(n). Where alpha(n) is inverse Ackerman function.
This function grows so slowly that that it doesn't exceed  4  for all reasonable  n  (approximately  n < 10^600).

### Related issues
#1285

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.