### PR TITLE
Forward X-Forwarded-For header to uWSGI. Closes #1318

### DIFF
--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -50,28 +50,21 @@ class Echo:
 
 
 def get_request_source_ip(request) -> str:
-    """Extract a normalized client IP from request metadata.
-
-    Preference order:
-    1) First valid IP from X-Forwarded-For
-    2) Valid REMOTE_ADDR
+    """Extract a normalized client IP from request metadata (X-Forwarded-For header)
 
     Raises:
         UnableToExtractSourceIPError: When no valid IP is found
     """
 
     forwarded_for = str(request.META.get("HTTP_X_FORWARDED_FOR", ""))
-    remote_addr = str(request.META.get("REMOTE_ADDR", "")).strip()
 
     candidates = [ip.strip() for ip in forwarded_for.split(",") if ip.strip()]
-    if remote_addr:
-        candidates.append(remote_addr)
 
     for candidate in candidates:
         if is_ip_address(candidate):
             return candidate
 
-    logger.error("Unable to extract valid source IP from request. X-Forwarded-For: %s, REMOTE_ADDR: %s", forwarded_for, remote_addr)
+    logger.error("Unable to extract valid source IP from request. X-Forwarded-For: %s", forwarded_for)
     raise UnableToExtractSourceIPError("No valid source IP found in request metadata")
 
 

--- a/configuration/nginx/http.conf
+++ b/configuration/nginx/http.conf
@@ -25,6 +25,7 @@ server {
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          45;
         include                     uwsgi_params;
+        uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
         client_max_body_size        20m;
     }
 
@@ -34,6 +35,7 @@ server {
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          600;
         include                     uwsgi_params;
+        uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
 
         gzip on;
         gzip_types application/json;
@@ -51,6 +53,7 @@ server {
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          45;
         include                     uwsgi_params;
+        uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
         client_max_body_size        20m;
     }
 

--- a/configuration/nginx/https.conf
+++ b/configuration/nginx/https.conf
@@ -41,6 +41,7 @@ server {
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          45;
         include                     uwsgi_params;
+        uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
         client_max_body_size        20m;
     }
 
@@ -50,6 +51,7 @@ server {
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          600;
         include                     uwsgi_params;
+        uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
 
         gzip on;
         gzip_types application/json;
@@ -67,6 +69,7 @@ server {
         uwsgi_pass_request_headers  on;
         uwsgi_read_timeout          45;
         include                     uwsgi_params;
+        uwsgi_param                 HTTP_X_FORWARDED_FOR $proxy_add_x_forwarded_for;
         client_max_body_size        20m;
     }
 

--- a/tests/api/views/test_validation_helpers.py
+++ b/tests/api/views/test_validation_helpers.py
@@ -40,27 +40,20 @@ class ValidationHelpersTestCase(CustomTestCase):
         self.assertFalse(is_sha256hash("z" * 64))  # Invalid chars
         self.assertFalse(is_sha256hash("not-a-hash"))
 
-    def test_get_request_source_ip_prefers_forwarded_for(self):
+    def test_get_request_source_ip(self):
         """The first valid X-Forwarded-For entry should be preferred."""
         request = SimpleNamespace(
             META={
                 "HTTP_X_FORWARDED_FOR": "203.0.113.5, 198.51.100.7",
-                "REMOTE_ADDR": "10.0.0.1",
             }
         )
         self.assertEqual(get_request_source_ip(request), "203.0.113.5")
-
-    def test_get_request_source_ip_uses_remote_addr(self):
-        """REMOTE_ADDR is used when no forwarded header is present."""
-        request = SimpleNamespace(META={"REMOTE_ADDR": "192.0.2.10"})
-        self.assertEqual(get_request_source_ip(request), "192.0.2.10")
 
     def test_get_request_source_ip_supports_ipv6(self):
         """IPv6 addresses should be accepted from forwarded header."""
         request = SimpleNamespace(
             META={
                 "HTTP_X_FORWARDED_FOR": "2001:db8::1",
-                "REMOTE_ADDR": "10.0.0.1",
             }
         )
         self.assertEqual(get_request_source_ip(request), "2001:db8::1")
@@ -70,7 +63,6 @@ class ValidationHelpersTestCase(CustomTestCase):
         request = SimpleNamespace(
             META={
                 "HTTP_X_FORWARDED_FOR": "unknown, not-an-ip",
-                "REMOTE_ADDR": "not-an-ip",
             }
         )
         with self.assertRaises(UnableToExtractSourceIPError):


### PR DESCRIPTION
# Description
The new function `get_request_source_ip` is logging errors on every Feeds page load because the X-Forwarded-For header never reaches the app. This adds the missing  `HTTP_X_FORWARDED_FOR` uwsgi parameter to each `uwsgi_pass` location in both nginx configs and removes the use of `REMOTE_ADDR` which is unavailable in Gunicorn's uwsgi mode.

### Related issues

Closes #1318.  

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [ ] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [ ] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
