### PR TITLE
Return 400 instead of 500 for invalid statistics pk

### DIFF
--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -5,7 +5,7 @@ import logging
 from certego_saas.ext.helpers import parse_humanized_range
 from django.db.models import Count, Q
 from django.db.models.functions import Trunc
-from django.http import HttpResponseServerError
+from django.http import HttpResponseBadRequest #changed here 
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -46,8 +46,8 @@ class StatisticsViewSet(viewsets.ViewSet):
         elif pk == "downloads":
             annotations = {"Downloads": Count("source", filter=Q(view=ViewType.FEEDS_VIEW.value))}
         else:
-            logger.error("this is impossible. check the code")
-            return HttpResponseServerError()
+            logger.warning(f"Unknown statistics type: {pk}")
+            return HttpResponseBadRequest("Unknown statistics type")
         return self.__aggregation_response_static_statistics(annotations)
 
     @action(detail=True, methods=["get"])
@@ -73,8 +73,8 @@ class StatisticsViewSet(viewsets.ViewSet):
         elif pk == "requests":
             annotations = {"Requests": Count("source", filter=Q(view=ViewType.ENRICHMENT_VIEW.value))}
         else:
-            logger.error("this is impossible. check the code")
-            return HttpResponseServerError()
+            logger.warning(f"Unknown statistics type: {pk}")
+            return HttpResponseBadRequest("Unknown statistics type")
         return self.__aggregation_response_static_statistics(annotations)
 
     @action(detail=False, methods=["get"])


### PR DESCRIPTION
Unknown statistics pk values are caused by invalid client input,
not server-side failures.

This changes the response from HTTP 500 to HTTP 400
for the feeds and enrichment actions.
