### PR TITLE
Return 400 Bad Request for unknown statistics pk values. Closes #1353

### DIFF
--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -5,7 +5,7 @@ import logging
 from certego_saas.ext.helpers import parse_humanized_range
 from django.db.models import Count, Q
 from django.db.models.functions import Trunc
-from django.http import HttpResponseServerError
+from django.http import HttpResponseBadRequest
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -46,8 +46,8 @@ class StatisticsViewSet(viewsets.ViewSet):
         elif pk == "downloads":
             annotations = {"Downloads": Count("source", filter=Q(view=ViewType.FEEDS_VIEW.value))}
         else:
-            logger.error("this is impossible. check the code")
-            return HttpResponseServerError()
+            logger.error(f"Invalid pk provided for feeds: {pk}")
+            return HttpResponseBadRequest()
         return self.__aggregation_response_static_statistics(annotations)
 
     @action(detail=True, methods=["get"])
@@ -73,8 +73,8 @@ class StatisticsViewSet(viewsets.ViewSet):
         elif pk == "requests":
             annotations = {"Requests": Count("source", filter=Q(view=ViewType.ENRICHMENT_VIEW.value))}
         else:
-            logger.error("this is impossible. check the code")
-            return HttpResponseServerError()
+            logger.error(f"Invalid pk provided for enrichment: {pk}")
+            return HttpResponseBadRequest()
         return self.__aggregation_response_static_statistics(annotations)
 
     @action(detail=False, methods=["get"])


### PR DESCRIPTION
# Description

Updated the `feeds` and `enrichment` actions in the `statistics` viewset. Previously, providing an unknown `pk` (URL segment) resulted in an `HttpResponseServerError` (HTTP 500). Since this is a client-side invalid request, the methods now correctly log a warning and return an `HttpResponseBadRequest` (HTTP 400).

### Related issues

Fixes #1353

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [ ] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [ ] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.