### PR TITLE
fix(news-widget): enforce strict UTC date parsing to prevent timezone…

### DIFF
--- a/frontend/src/components/home/NewsWidget.jsx
+++ b/frontend/src/components/home/NewsWidget.jsx
@@ -12,11 +12,14 @@ export const NewsWidget = React.memo(() => {
     if (!dateStr) return "";
 
     const date = new Date(dateStr);
-    if (isNaN(date.getTime())) return dateStr;
+    if (isNaN(date.getTime())) return String(dateStr);
 
-    const day = date.getDate();
-    const month = date.toLocaleDateString("en-US", { month: "short" });
-    const year = date.getFullYear();
+    const day = date.getUTCDate();
+    const month = date.toLocaleDateString("en-US", {
+      month: "short",
+      timeZone: "UTC",
+    });
+    const year = date.getUTCFullYear();
 
     const ordinals = ["th", "st", "nd", "rd"];
     const v = day % 100;
@@ -33,6 +36,7 @@ export const NewsWidget = React.memo(() => {
         }
         return response.json();
       })
+
       .then(setData)
       .catch((err) => {
         console.error("Error fetching news:", err);

--- a/frontend/tests/components/home/NewsWidget.test.jsx
+++ b/frontend/tests/components/home/NewsWidget.test.jsx
@@ -20,7 +20,6 @@ describe("NewsWidget", () => {
       fetch.mockImplementation(() => new Promise(() => {}));
 
       render(<NewsWidget />);
-
       expect(screen.getByText("Loading news...")).toBeInTheDocument();
       expect(screen.getByRole("status")).toBeInTheDocument();
     });
@@ -156,6 +155,32 @@ describe("NewsWidget", () => {
   });
 
   describe("Date Formatting", () => {
+    it("should format date correctly in non-utc timezones", async () => {
+      const originalTZ = process.env.TZ;
+      process.env.TZ = "America/Los_Angeles";
+
+      try {
+        const mockNewsDataUTC = [
+          {
+            date: "2024-01-01",
+            title: "updated_timezone",
+            subtext: "Testing for utc formating",
+            link: "L1_utc",
+          },
+        ];
+        fetch.mockResolvedValueOnce({
+          ok: true,
+          json: async () => mockNewsDataUTC,
+        });
+        render(<NewsWidget />);
+
+        const dateElement = await screen.findByText("1st Jan 2024");
+        expect(dateElement).toBeInTheDocument();
+        expect(screen.queryByText("31st Dec 2023")).not.toBeInTheDocument();
+      } finally {
+        process.env.TZ = originalTZ;
+      }
+    });
     it("should format date correctly with ordinal suffix", async () => {
       const mockNewsData = [
         { date: "2024-01-01", title: "N1", subtext: "T", link: "L1" },


### PR DESCRIPTION
# Description
This PR fixes a bug where the NewsWidget displays the wrong date for users in Western timezones (for example, showing "31st Dec 2023" instead of "2024-01-01").

The app was using the user's local computer time to read a UTC date string. The bug was fixed by forcing the code to use UTC everywhere (`getUTCDate()` and `timeZone: "UTC"`). Now, everyone sees the exact same correct date no matter where they live.

### Related issues
Closes #1362

### Type of change

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [X] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [X] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [X] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [X] My branch is based on `develop`.
- [X] The pull request is for the branch `develop`.
- [X] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [X] I documented my code changes with docstrings and/or comments.
- [X] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [X] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [X] I have added tests for the feature/bug I solved.
- [X] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [X] I have provided a screenshot of the result in the PR.
- [] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
