### PR TITLE
Add login rate limiting. Closes #1383 

### DIFF
--- a/authentication/throttles.py
+++ b/authentication/throttles.py
@@ -2,7 +2,7 @@ from rest_framework.throttling import SimpleRateThrottle
 
 
 class LoginIPThrottle(SimpleRateThrottle):
-    scope = "auth_login_ip"
+    scope = "login"
 
     def get_cache_key(self, request, view):
         return self.cache_format % {
@@ -12,7 +12,7 @@ class LoginIPThrottle(SimpleRateThrottle):
 
 
 class LoginIdentifierThrottle(SimpleRateThrottle):
-    scope = "auth_login_identifier"
+    scope = "login"
 
     def get_cache_key(self, request, view):
         identifier = request.data.get("username") or request.data.get("email")

--- a/authentication/throttles.py
+++ b/authentication/throttles.py
@@ -1,0 +1,29 @@
+from rest_framework.throttling import SimpleRateThrottle
+
+
+class LoginIPThrottle(SimpleRateThrottle):
+    scope = "auth_login_ip"
+
+    def get_cache_key(self, request, view):
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": self.get_ident(request),
+        }
+
+
+class LoginIdentifierThrottle(SimpleRateThrottle):
+    scope = "auth_login_identifier"
+
+    def get_cache_key(self, request, view):
+        identifier = request.data.get("username") or request.data.get("email")
+        if not isinstance(identifier, str):
+            return None
+
+        normalized = identifier.strip().lower()
+        if not normalized:
+            return None
+
+        return self.cache_format % {
+            "scope": self.scope,
+            "ident": normalized,
+        }

--- a/authentication/throttles.py
+++ b/authentication/throttles.py
@@ -2,6 +2,8 @@ from rest_framework.throttling import SimpleRateThrottle
 
 
 class LoginIPThrottle(SimpleRateThrottle):
+    """Rate-limit login attempts from the same IP address."""
+
     scope = "login"
 
     def get_cache_key(self, request, view):
@@ -12,6 +14,8 @@ class LoginIPThrottle(SimpleRateThrottle):
 
 
 class LoginIdentifierThrottle(SimpleRateThrottle):
+    """Rate-limit login attempts against the same username or email."""
+
     scope = "login"
 
     def get_cache_key(self, request, view):

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -30,6 +30,7 @@ from .serializers import (
     LoginSerializer,
     RegistrationSerializer,
 )
+from .throttles import LoginIdentifierThrottle, LoginIPThrottle
 
 logger = logging.getLogger(__name__)
 
@@ -124,6 +125,8 @@ def check_configuration(request):
 
 
 class LoginView(certego_views.LoginView):
+    throttle_classes = [LoginIPThrottle, LoginIdentifierThrottle]
+
     @staticmethod
     def validate_and_return_user(request):
         serializer = LoginSerializer(data=request.data)

--- a/docker/env_file_template
+++ b/docker/env_file_template
@@ -90,6 +90,9 @@ FEEDS_THROTTLE_RATE=30/minute
 FEEDS_ADVANCED_THROTTLE_RATE=100/minute
 FEEDS_SHARED_THROTTLE_RATE=10/minute
 
+# Rate limiting for authentication endpoints (format: number/period, e.g. 30/minute)
+LOGIN_THROTTLE_RATE=10/minute
+
 # Trending attackers settings
 # Max API window in minutes (must be >= 60 and multiple of 60)
 TRENDING_MAX_WINDOW_MINUTES=22320

--- a/greedybear/settings.py
+++ b/greedybear/settings.py
@@ -139,8 +139,7 @@ REST_FRAMEWORK = {
         "feeds": os.environ.get("FEEDS_THROTTLE_RATE", "30/minute"),
         "feeds_advanced": os.environ.get("FEEDS_ADVANCED_THROTTLE_RATE", "100/minute"),
         "feeds_shared": os.environ.get("FEEDS_SHARED_THROTTLE_RATE", "10/minute"),
-        "auth_login_ip": os.environ.get("AUTH_LOGIN_IP_THROTTLE_RATE", "10/minute"),
-        "auth_login_identifier": os.environ.get("AUTH_LOGIN_IDENTIFIER_THROTTLE_RATE", "5/minute"),
+        "login": os.environ.get("LOGIN_THROTTLE_RATE", "10/minute"),
     },
     # Disable DRF's format suffix negotiation via ?format= query param,
     # since feeds endpoints handle the format parameter internally.

--- a/greedybear/settings.py
+++ b/greedybear/settings.py
@@ -139,6 +139,8 @@ REST_FRAMEWORK = {
         "feeds": os.environ.get("FEEDS_THROTTLE_RATE", "30/minute"),
         "feeds_advanced": os.environ.get("FEEDS_ADVANCED_THROTTLE_RATE", "100/minute"),
         "feeds_shared": os.environ.get("FEEDS_SHARED_THROTTLE_RATE", "10/minute"),
+        "auth_login_ip": os.environ.get("AUTH_LOGIN_IP_THROTTLE_RATE", "10/minute"),
+        "auth_login_identifier": os.environ.get("AUTH_LOGIN_IDENTIFIER_THROTTLE_RATE", "5/minute"),
     },
     # Disable DRF's format suffix negotiation via ?format= query param,
     # since feeds endpoints handle the format parameter internally.

--- a/tests/authentication/test_auth.py
+++ b/tests/authentication/test_auth.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.cache import cache
@@ -5,6 +7,9 @@ from django.test import tag
 from durin.models import AuthToken, Client
 from rest_email_auth.models import EmailConfirmation, PasswordResetToken
 from rest_framework.reverse import reverse
+from rest_framework.test import APIClient
+
+from authentication.throttles import LoginIdentifierThrottle, LoginIPThrottle
 
 from . import CustomOAuthTestCase
 
@@ -68,6 +73,32 @@ class TestUserAuth(CustomOAuthTestCase):
         response = self.client.post(login_uri, body)
         self.assertEqual(response.status_code, 200)
         self.assertIsNone(cache.get("current_site"))
+
+    def test_login_rate_limit_by_ip(self):
+        cache.clear()
+        body = {**self.creds}
+
+        with patch.object(LoginIPThrottle, "THROTTLE_RATES", {"auth_login_ip": "1/minute"}):
+            response_1 = self.client.post(login_uri, body)
+            response_2 = self.client.post(login_uri, body)
+        cache.clear()
+
+        self.assertEqual(response_1.status_code, 200, msg=response_1.cookies)
+        self.assertEqual(response_2.status_code, 429, msg=response_2.content)
+
+    def test_login_rate_limit_by_identifier(self):
+        cache.clear()
+        client_1 = APIClient()
+        client_2 = APIClient(REMOTE_ADDR="203.0.113.10")
+        body = {**self.creds}
+
+        with patch.object(LoginIdentifierThrottle, "THROTTLE_RATES", {"auth_login_identifier": "1/minute"}):
+            response_1 = client_1.post(login_uri, body)
+            response_2 = client_2.post(login_uri, {"username": self.creds["username"].upper(), "password": body["password"]})
+        cache.clear()
+
+        self.assertEqual(response_1.status_code, 200, msg=response_1.cookies)
+        self.assertEqual(response_2.status_code, 429, msg=response_2.content)
 
     def test_logout_204(self):
         self.assertEqual(AuthToken.objects.count(), 0)

--- a/tests/authentication/test_auth.py
+++ b/tests/authentication/test_auth.py
@@ -78,7 +78,7 @@ class TestUserAuth(CustomOAuthTestCase):
         cache.clear()
         body = {**self.creds}
 
-        with patch.object(LoginIPThrottle, "THROTTLE_RATES", {"auth_login_ip": "1/minute"}):
+        with patch.object(LoginIPThrottle, "THROTTLE_RATES", {"login": "1/minute"}):
             response_1 = self.client.post(login_uri, body)
             response_2 = self.client.post(login_uri, body)
         cache.clear()
@@ -92,7 +92,7 @@ class TestUserAuth(CustomOAuthTestCase):
         client_2 = APIClient(REMOTE_ADDR="203.0.113.10")
         body = {**self.creds}
 
-        with patch.object(LoginIdentifierThrottle, "THROTTLE_RATES", {"auth_login_identifier": "1/minute"}):
+        with patch.object(LoginIdentifierThrottle, "THROTTLE_RATES", {"login": "1/minute"}):
             response_1 = client_1.post(login_uri, body)
             response_2 = client_2.post(login_uri, {"username": self.creds["username"].upper(), "password": body["password"]})
         cache.clear()


### PR DESCRIPTION
## Description

Add explicit rate limiting to `POST /api/auth/login` to reduce brute-force risk.

This change introduces two login-specific DRF throttles:

- an IP-based throttle to limit repeated attempts from the same source
- an identifier-based throttle to limit repeated attempts against the same username/email

The new throttle rates are configurable through environment variables, following the same pattern already used for feeds throttling.

### Related issues

- Closes #1383 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [ ] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.