### PR TITLE
Cache IOC-backed statistics aggregations. Closes #1405

### DIFF
--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -24,6 +24,9 @@ class StatisticsViewSet(CachedResponseMixin, viewsets.ViewSet):
     as well as statistics on enrichment data.
     """
 
+    # Only cache statistics derived from IOC data that is refreshed by the extraction.
+    # These actions can use extraction-driven invalidation; user/request-dependent statistics
+    # should stay uncached here so they reflect the latest per-user state.
     cache_namespace = "statistics_ioc"
     cacheable_actions = frozenset({"countries", "feeds_types"})
 

--- a/api/views/statistics.py
+++ b/api/views/statistics.py
@@ -10,18 +10,25 @@ from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from api.mixins import CachedResponseMixin
 from greedybear.models import IOC, Honeypot, Statistics, ViewType
 
 logger = logging.getLogger(__name__)
 
 
-class StatisticsViewSet(viewsets.ViewSet):
+class StatisticsViewSet(CachedResponseMixin, viewsets.ViewSet):
     """
     A viewset for viewing and editing statistics related to feeds and enrichment data.
 
     Provides actions to retrieve statistics about the sources and downloads of feeds,
     as well as statistics on enrichment data.
     """
+
+    cache_namespace = "statistics_ioc"
+    cacheable_actions = frozenset({"countries", "feeds_types"})
+
+    def _cache_enabled(self) -> bool:
+        return getattr(self, "action", None) in self.cacheable_actions
 
     @action(detail=True, methods=["GET"])
     def feeds(self, request, pk=None):
@@ -88,6 +95,10 @@ class StatisticsViewSet(viewsets.ViewSet):
         Returns:
             Response: A JSON list of {country, code, count} objects ordered by count descending.
         """
+        cached_response = self.get_cached_response()
+        if cached_response is not None:
+            return cached_response
+
         delta, _ = self.__parse_range(self.request)
         qs = (
             IOC.objects.filter(last_seen__gte=delta)
@@ -118,6 +129,10 @@ class StatisticsViewSet(viewsets.ViewSet):
         Returns:
             Response: A JSON response containing the feed type statistics.
         """
+        cached_response = self.get_cached_response()
+        if cached_response is not None:
+            return cached_response
+
         # Build annotations for each active general honeypot
         annotations = {}
         honeypots = Honeypot.objects.all().filter(active=True)

--- a/tests/api/views/test_statistics_view.py
+++ b/tests/api/views/test_statistics_view.py
@@ -1,5 +1,20 @@
-from greedybear.models import Honeypot, Statistics, ViewType
+from django.test import override_settings
+
+from greedybear.cache import Cache
+from greedybear.consts import API_CACHE_ALIAS, IOC_DATA_VERSION_KEY
+from greedybear.models import IOC, Honeypot, IocType, Statistics, ViewType
 from tests import CustomTestCase
+
+TEST_CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "greedybear-default",
+    },
+    "api": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "greedybear-test-statistics-api-cache",
+    },
+}
 
 
 class StatisticsViewTestCase(CustomTestCase):
@@ -74,3 +89,89 @@ class StatisticsViewTestCase(CustomTestCase):
         # Results must be ordered descending by count
         count_values = [item["count"] for item in data]
         self.assertEqual(count_values, sorted(count_values, reverse=True))
+
+
+@override_settings(CACHES=TEST_CACHES)
+class StatisticsIocCacheTestCase(CustomTestCase):
+    def _create_country_ioc(self, name: str, country: str, code: str) -> IOC:
+        ioc = IOC.objects.create(
+            name=name,
+            type=IocType.IP.value,
+            first_seen=self.current_time,
+            last_seen=self.current_time,
+            days_seen=[self.current_time.date()],
+            number_of_days_seen=1,
+            attack_count=1,
+            interaction_count=1,
+            scanner=True,
+            payload_request=True,
+            related_urls=[],
+            ip_reputation="",
+            destination_ports=[22],
+            login_attempts=1,
+            recurrence_probability=0.1,
+            expected_interactions=1.0,
+            attacker_country=country,
+            attacker_country_code=code,
+        )
+        ioc.honeypots.add(self.cowrie_hp)
+        ioc.save()
+        return ioc
+
+    def _country_names(self, response) -> set[str]:
+        return {item["country"] for item in response.json()}
+
+    def test_countries_response_is_cached_then_invalidated_by_version_bump(self):
+        url = "/api/statistics/countries?range=7d"
+
+        first = self.client.get(url)
+        self.assertEqual(first.status_code, 200)
+        baseline = self._country_names(first)
+        self.assertIn("China", baseline)
+
+        self._create_country_ioc("22.3.4.66", "Japan", "JP")
+        cached = self.client.get(url)
+        self.assertEqual(cached.status_code, 200)
+        self.assertEqual(self._country_names(cached), baseline)
+        self.assertNotIn("Japan", self._country_names(cached))
+
+        Cache(API_CACHE_ALIAS).bump_data_version(IOC_DATA_VERSION_KEY)
+        fresh = self.client.get(url)
+        self.assertEqual(fresh.status_code, 200)
+        self.assertIn("Japan", self._country_names(fresh))
+
+    def test_countries_cache_key_includes_range(self):
+        seven_day = "/api/statistics/countries?range=7d"
+        one_day = "/api/statistics/countries?range=1d"
+
+        first = self.client.get(seven_day)
+        self.assertEqual(first.status_code, 200)
+        seven_day_baseline = self._country_names(first)
+
+        self._create_country_ioc("22.3.4.67", "Japan", "JP")
+        different_range = self.client.get(one_day)
+        self.assertEqual(different_range.status_code, 200)
+        self.assertEqual(self._country_names(self.client.get(seven_day)), seven_day_baseline)
+        self.assertIn("Japan", self._country_names(different_range))
+
+    def test_feeds_types_response_is_cached_then_invalidated_by_version_bump(self):
+        url = "/api/statistics/feeds_types?range=7d"
+
+        first = self.client.get(url)
+        self.assertEqual(first.status_code, 200)
+        baseline = first.json()[0]
+
+        tanner = Honeypot.objects.create(name="Tanner", active=True)
+        ioc = self._create_country_ioc("22.3.4.68", "Japan", "JP")
+        ioc.honeypots.add(tanner)
+        ioc.save()
+
+        cached = self.client.get(url)
+        self.assertEqual(cached.status_code, 200)
+        self.assertEqual(cached.json()[0], baseline)
+        self.assertNotIn("Tanner", cached.json()[0])
+
+        Cache(API_CACHE_ALIAS).bump_data_version(IOC_DATA_VERSION_KEY)
+        fresh = self.client.get(url)
+        self.assertEqual(fresh.status_code, 200)
+        self.assertEqual(fresh.json()[0]["Tanner"], 1)


### PR DESCRIPTION
# Description

Adds server-side caching for the IOC-backed statistics aggregation endpoints used by the dashboard:

- `GET /api/statistics/countries?range=...`
- `GET /api/statistics/feeds_types?range=...`

These endpoints now reuse the existing versioned API cache infrastructure and are invalidated through the existing IOC data version bump after extraction processes IOC records. The request-log statistics endpoints are left unchanged.

### Related issues

Closes #1405 

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.