### PR TITLE
refactor(cronjobs): migrate threatfox_feed, abuseipdb_feed, and extraction/utils to HttpClient. Refs #1214

### DIFF
--- a/greedybear/cronjobs/abuseipdb_feed.py
+++ b/greedybear/cronjobs/abuseipdb_feed.py
@@ -2,6 +2,7 @@ import requests
 from django.conf import settings
 
 from greedybear.cronjobs.base import Cronjob
+from greedybear.cronjobs.http_client import HttpClient
 from greedybear.cronjobs.repositories.tag import TagRepository
 from greedybear.models import IOC
 from greedybear.utils import is_valid_ipv4
@@ -60,8 +61,8 @@ class AbuseIPDBCron(Cronjob):
                 "limit": self.MAX_ENTRIES,  # Maximum 10k entries
             }
 
-            response = requests.get(url, headers=headers, params=params, timeout=30)
-            response.raise_for_status()
+            with HttpClient() as client:
+                response = client.get(url, headers=headers, params=params, timeout=30)
 
             json_data = response.json()
             blocklist_data = json_data.get("data", [])

--- a/greedybear/cronjobs/extraction/utils.py
+++ b/greedybear/cronjobs/extraction/utils.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 import requests
 from django.conf import settings
 
+from greedybear.cronjobs.http_client import HttpClient
 from greedybear.cronjobs.repositories import ASRepository
 from greedybear.enums import IpReputation
 from greedybear.models import IOC, FireHolList, MassScanner
@@ -243,12 +244,13 @@ def threatfox_submission(ioc_record: IOC, related_urls: list, log: Logger) -> No
         "iocs": urls_to_submit,
     }
     try:
-        r = requests.post(
-            "https://threatfox-api.abuse.ch/api/v1/",
-            headers=headers,
-            json=json_data,
-            timeout=5,
-        )
+        with HttpClient() as client:
+            r = client.post(
+                "https://threatfox-api.abuse.ch/api/v1/",
+                headers=headers,
+                json=json_data,
+                timeout=5,
+            )
     except requests.RequestException:
         log.exception("Threatfox push error")
     else:

--- a/greedybear/cronjobs/threatfox_feed.py
+++ b/greedybear/cronjobs/threatfox_feed.py
@@ -5,6 +5,7 @@ import requests
 from django.conf import settings
 
 from greedybear.cronjobs.base import Cronjob
+from greedybear.cronjobs.http_client import HttpClient
 from greedybear.cronjobs.repositories.tag import TagRepository
 from greedybear.models import IOC
 from greedybear.utils import is_valid_ipv4
@@ -60,8 +61,8 @@ class ThreatFoxCron(Cronjob):
             }
             data = {"query": "get_iocs", "days": 7}
 
-            response = requests.post(url, json=data, headers=headers, timeout=30)
-            response.raise_for_status()
+            with HttpClient() as client:
+                response = client.post(url, json=data, headers=headers, timeout=30)
 
             json_data = response.json()
 

--- a/tests/test_abuseipdb.py
+++ b/tests/test_abuseipdb.py
@@ -24,7 +24,7 @@ class TestAbuseIPDBCron(CustomTestCase):
 
         self.assertEqual(Tag.objects.filter(source="abuseipdb").count(), 0)
 
-    @patch("greedybear.cronjobs.abuseipdb_feed.requests.get")
+    @patch("greedybear.cronjobs.abuseipdb_feed.HttpClient.get")
     @patch("greedybear.cronjobs.abuseipdb_feed.settings")
     def test_enriches_matching_iocs(self, mock_settings, mock_get):
         """Should create tags for IOCs that match blocklist IPs."""
@@ -39,7 +39,6 @@ class TestAbuseIPDBCron(CustomTestCase):
                 }
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         self.cron.run()
@@ -53,7 +52,7 @@ class TestAbuseIPDBCron(CustomTestCase):
         confidence_tag = tags.get(key="confidence_of_abuse")
         self.assertEqual(confidence_tag.value, "84%")
 
-    @patch("greedybear.cronjobs.abuseipdb_feed.requests.get")
+    @patch("greedybear.cronjobs.abuseipdb_feed.HttpClient.get")
     @patch("greedybear.cronjobs.abuseipdb_feed.settings")
     def test_no_tags_for_non_matching_iocs(self, mock_settings, mock_get):
         """Should not create tags for IPs not in our IOC table."""
@@ -68,14 +67,13 @@ class TestAbuseIPDBCron(CustomTestCase):
                 }
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         self.cron.run()
 
         self.assertEqual(Tag.objects.filter(source="abuseipdb").count(), 0)
 
-    @patch("greedybear.cronjobs.abuseipdb_feed.requests.get")
+    @patch("greedybear.cronjobs.abuseipdb_feed.HttpClient.get")
     @patch("greedybear.cronjobs.abuseipdb_feed.settings")
     def test_replaces_stale_tags(self, mock_settings, mock_get):
         """Tags should be replaced on each run, not accumulated."""
@@ -94,7 +92,6 @@ class TestAbuseIPDBCron(CustomTestCase):
                 }
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         self.cron.run()
@@ -104,7 +101,7 @@ class TestAbuseIPDBCron(CustomTestCase):
         self.assertEqual(confidence_tags.count(), 1)
         self.assertEqual(confidence_tags.first().value, "95%")
 
-    @patch("greedybear.cronjobs.abuseipdb_feed.requests.get")
+    @patch("greedybear.cronjobs.abuseipdb_feed.HttpClient.get")
     @patch("greedybear.cronjobs.abuseipdb_feed.settings")
     def test_clears_tags_when_ip_delisted(self, mock_settings, mock_get):
         """Tags should be removed when an IP is no longer in the blocklist."""
@@ -116,14 +113,13 @@ class TestAbuseIPDBCron(CustomTestCase):
         # New run with empty blocklist (IP delisted)
         mock_response = Mock()
         mock_response.json.return_value = {"data": []}
-        mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         self.cron.run()
 
         self.assertEqual(Tag.objects.filter(source="abuseipdb", ioc=self.ioc).count(), 0)
 
-    @patch("greedybear.cronjobs.abuseipdb_feed.requests.get")
+    @patch("greedybear.cronjobs.abuseipdb_feed.HttpClient.get")
     @patch("greedybear.cronjobs.abuseipdb_feed.settings")
     def test_handles_request_exception(self, mock_settings, mock_get):
         """Should raise on network errors."""
@@ -133,7 +129,7 @@ class TestAbuseIPDBCron(CustomTestCase):
         with self.assertRaises(requests.RequestException):
             self.cron.run()
 
-    @patch("greedybear.cronjobs.abuseipdb_feed.requests.get")
+    @patch("greedybear.cronjobs.abuseipdb_feed.HttpClient.get")
     @patch("greedybear.cronjobs.abuseipdb_feed.settings")
     def test_skips_invalid_ips(self, mock_settings, mock_get):
         """Should skip entries with invalid IP addresses."""
@@ -152,14 +148,13 @@ class TestAbuseIPDBCron(CustomTestCase):
                 },
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         self.cron.run()
 
         self.assertEqual(Tag.objects.filter(source="abuseipdb").count(), 0)
 
-    @patch("greedybear.cronjobs.abuseipdb_feed.requests.get")
+    @patch("greedybear.cronjobs.abuseipdb_feed.HttpClient.get")
     @patch("greedybear.cronjobs.abuseipdb_feed.settings")
     def test_does_not_affect_threatfox_tags(self, mock_settings, mock_get):
         """AbuseIPDB enrichment should not touch tags from other sources."""
@@ -170,7 +165,6 @@ class TestAbuseIPDBCron(CustomTestCase):
 
         mock_response = Mock()
         mock_response.json.return_value = {"data": []}
-        mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         self.cron.run()
@@ -178,7 +172,7 @@ class TestAbuseIPDBCron(CustomTestCase):
         # ThreatFox tag should still exist
         self.assertEqual(Tag.objects.filter(source="threatfox").count(), 1)
 
-    @patch("greedybear.cronjobs.abuseipdb_feed.requests.get")
+    @patch("greedybear.cronjobs.abuseipdb_feed.HttpClient.get")
     @patch("greedybear.cronjobs.abuseipdb_feed.settings")
     def test_enriches_multiple_iocs(self, mock_settings, mock_get):
         """Should enrich multiple IOCs from a single feed download."""
@@ -197,7 +191,6 @@ class TestAbuseIPDBCron(CustomTestCase):
                 },
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
 
         self.cron.run()

--- a/tests/test_extraction_utils.py
+++ b/tests/test_extraction_utils.py
@@ -536,7 +536,7 @@ class ThreatfoxSubmissionTestCase(ExtractionTestCase):
         threatfox_submission(ioc_record, ["http://malicious.com", "http://evil.com/"], self.mock_log)
         self.assertTrue(any("skipping" in str(call) for call in self.mock_log.info.call_args_list))
 
-    @patch("greedybear.cronjobs.extraction.utils.requests.post")
+    @patch("greedybear.cronjobs.extraction.utils.HttpClient.post")
     @patch("greedybear.cronjobs.extraction.utils.settings")
     def test_submits_urls_with_path(self, mock_settings, mock_post):
         mock_settings.THREATFOX_API_KEY = "test-key"
@@ -551,7 +551,7 @@ class ThreatfoxSubmissionTestCase(ExtractionTestCase):
         self.assertEqual(call_kwargs["headers"]["Auth-Key"], "test-key")
         self.assertIn("http://malicious.com/payload.sh", call_kwargs["json"]["iocs"])
 
-    @patch("greedybear.cronjobs.extraction.utils.requests.post")
+    @patch("greedybear.cronjobs.extraction.utils.HttpClient.post")
     @patch("greedybear.cronjobs.extraction.utils.settings")
     def test_includes_honeypot_names_in_comment(self, mock_settings, mock_post):
         mock_settings.THREATFOX_API_KEY = "test-key"
@@ -571,7 +571,7 @@ class ThreatfoxSubmissionTestCase(ExtractionTestCase):
         self.assertIn("Log4pot", comment)
         self.assertIn("Dionaea", comment)
 
-    @patch("greedybear.cronjobs.extraction.utils.requests.post")
+    @patch("greedybear.cronjobs.extraction.utils.HttpClient.post")
     @patch("greedybear.cronjobs.extraction.utils.settings")
     def test_logs_successful_submission(self, mock_settings, mock_post):
         mock_settings.THREATFOX_API_KEY = "test-key"
@@ -585,7 +585,7 @@ class ThreatfoxSubmissionTestCase(ExtractionTestCase):
         mock_settings.THREATFOX_API_KEY = "test-key"
         ioc_record = self._create_mock_payload_request()
 
-        with patch("greedybear.cronjobs.extraction.utils.requests.post") as mock_post:
+        with patch("greedybear.cronjobs.extraction.utils.HttpClient.post") as mock_post:
             mock_post.return_value = Mock(text='{"status": "ok"}')
             urls = [
                 "http://malicious.com",  # No path - skip

--- a/tests/test_threatfox.py
+++ b/tests/test_threatfox.py
@@ -24,7 +24,7 @@ class TestThreatFoxCron(CustomTestCase):
 
         self.assertEqual(Tag.objects.filter(source="threatfox").count(), 0)
 
-    @patch("greedybear.cronjobs.threatfox_feed.requests.post")
+    @patch("greedybear.cronjobs.threatfox_feed.HttpClient.post")
     @patch("greedybear.cronjobs.threatfox_feed.settings")
     def test_enriches_matching_iocs(self, mock_settings, mock_post):
         """Should create tags for IOCs that match feed IPs."""
@@ -45,7 +45,6 @@ class TestThreatFoxCron(CustomTestCase):
                 }
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
 
         self.cron.run()
@@ -61,7 +60,7 @@ class TestThreatFoxCron(CustomTestCase):
         malware_tag = tags.get(key="malware")
         self.assertEqual(malware_tag.value, "Mirai")
 
-    @patch("greedybear.cronjobs.threatfox_feed.requests.post")
+    @patch("greedybear.cronjobs.threatfox_feed.HttpClient.post")
     @patch("greedybear.cronjobs.threatfox_feed.settings")
     def test_no_tags_for_non_matching_iocs(self, mock_settings, mock_post):
         """Should not create tags for IPs not in our IOC table."""
@@ -80,14 +79,13 @@ class TestThreatFoxCron(CustomTestCase):
                 }
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
 
         self.cron.run()
 
         self.assertEqual(Tag.objects.filter(source="threatfox").count(), 0)
 
-    @patch("greedybear.cronjobs.threatfox_feed.requests.post")
+    @patch("greedybear.cronjobs.threatfox_feed.HttpClient.post")
     @patch("greedybear.cronjobs.threatfox_feed.settings")
     def test_replaces_stale_tags(self, mock_settings, mock_post):
         """Tags should be replaced on each run, not accumulated."""
@@ -110,7 +108,6 @@ class TestThreatFoxCron(CustomTestCase):
                 }
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
 
         self.cron.run()
@@ -121,7 +118,7 @@ class TestThreatFoxCron(CustomTestCase):
         self.assertEqual(malware_tags.count(), 1)
         self.assertEqual(malware_tags.first().value, "NewMalware")
 
-    @patch("greedybear.cronjobs.threatfox_feed.requests.post")
+    @patch("greedybear.cronjobs.threatfox_feed.HttpClient.post")
     @patch("greedybear.cronjobs.threatfox_feed.settings")
     def test_clears_tags_when_ip_delisted(self, mock_settings, mock_post):
         """Tags should be removed when an IP is no longer in the feed."""
@@ -136,7 +133,6 @@ class TestThreatFoxCron(CustomTestCase):
             "query_status": "ok",
             "data": [],
         }
-        mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
 
         self.cron.run()
@@ -144,7 +140,7 @@ class TestThreatFoxCron(CustomTestCase):
         # Tags should be gone
         self.assertEqual(Tag.objects.filter(source="threatfox", ioc=self.ioc).count(), 0)
 
-    @patch("greedybear.cronjobs.threatfox_feed.requests.post")
+    @patch("greedybear.cronjobs.threatfox_feed.HttpClient.post")
     @patch("greedybear.cronjobs.threatfox_feed.settings")
     def test_skips_private_ips(self, mock_settings, mock_post):
         """Should filter out private, loopback, and reserved IPs."""
@@ -170,14 +166,13 @@ class TestThreatFoxCron(CustomTestCase):
                 },
             ],
         }
-        mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
 
         self.cron.run()
 
         self.assertEqual(Tag.objects.filter(source="threatfox").count(), 0)
 
-    @patch("greedybear.cronjobs.threatfox_feed.requests.post")
+    @patch("greedybear.cronjobs.threatfox_feed.HttpClient.post")
     @patch("greedybear.cronjobs.threatfox_feed.settings")
     def test_handles_non_ok_status(self, mock_settings, mock_post):
         """Should handle non-OK API response gracefully."""
@@ -188,14 +183,13 @@ class TestThreatFoxCron(CustomTestCase):
             "query_status": "no_result",
             "data": [],
         }
-        mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
 
         self.cron.run()
 
         self.assertEqual(Tag.objects.filter(source="threatfox").count(), 0)
 
-    @patch("greedybear.cronjobs.threatfox_feed.requests.post")
+    @patch("greedybear.cronjobs.threatfox_feed.HttpClient.post")
     @patch("greedybear.cronjobs.threatfox_feed.settings")
     def test_handles_request_exception(self, mock_settings, mock_post):
         """Should raise on network errors."""
@@ -220,7 +214,7 @@ class TestThreatFoxCron(CustomTestCase):
         ip = ThreatFoxCron._extract_ip("evil.example.com", "domain")
         self.assertIsNone(ip)
 
-    @patch("greedybear.cronjobs.threatfox_feed.requests.post")
+    @patch("greedybear.cronjobs.threatfox_feed.HttpClient.post")
     @patch("greedybear.cronjobs.threatfox_feed.settings")
     def test_does_not_affect_abuseipdb_tags(self, mock_settings, mock_post):
         """ThreatFox enrichment should not touch tags from other sources."""
@@ -231,7 +225,6 @@ class TestThreatFoxCron(CustomTestCase):
 
         mock_response = Mock()
         mock_response.json.return_value = {"query_status": "ok", "data": []}
-        mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
 
         self.cron.run()


### PR DESCRIPTION
## Description

This PR handles the third batch of standardising our cron jobs HTTP fetchers, as discussed in #1214.

It migrates the `threatfox_feed`, `abuseipdb_feed`, and `extraction/utils.py` (`threatfox_submission`) endpoints to utilise the centralised `HttpClient` wrapper introduced in #1253. This refactor replaces ad-hoc `requests.get`/`requests.post` calls with the shared client, ensuring standardised error handling, built-in logging, and automatic retries for server errors.

Key details:
- `threatfox_feed`: Migrated `requests.post()` → `HttpClient().post()`. Removed manual `raise_for_status()` (handled by `HttpClient` automatically).
- `abuseipdb_feed`: Migrated `requests.get()` → `HttpClient().get()`. Removed manual `raise_for_status()`.
- `extraction/utils.py`: Migrated `requests.post()` in `threatfox_submission()` → `HttpClient().post()`. The existing error-swallowing behaviour (catch `RequestException` without re-raising) is preserved to avoid crashing the extraction pipeline on submission failures.

All test mocks updated from patching `requests.get`/`requests.post` to patching `HttpClient.get`/`HttpClient.post`, and unnecessary `raise_for_status` mock setup lines were removed.

## Related issues

- Refs #1214
- Depends on #1253, #1254, #1309

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

## Checklist

### Formalities

- [x] I have read and understood the rules about how to Contribute to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop` (via the wrapper branch).
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behaviour that is described in the docs. If so, I also included an update to the wiki in the description of this PR.
- [x] Linter (Ruff) gave 0 errors. If you have correctly installed pre-commit, it runs these checks and makes these adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

_N/A - no GUI changes in this PR._
