### PR TITLE
refactor(fetchers): migrate ntfy and get_greedybear_news to HttpClient. Refs #1214

### DIFF
--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -5,7 +5,6 @@ import uuid
 from datetime import timedelta
 
 import feedparser
-import requests
 from django.conf import settings
 from django.contrib.postgres.aggregates import ArrayAgg
 from django.core.cache import cache
@@ -16,6 +15,7 @@ from rest_framework.response import Response
 from stix2 import Bundle, ExternalReference, Indicator
 
 from greedybear.consts import APISOURCE_LOCKED_THRESHOLD, CACHE_KEY_GREEDYBEAR_NEWS, CACHE_TIMEOUT_SECONDS, RSS_FEED_URL
+from greedybear.cronjobs.http_client import HttpClient
 from greedybear.models import APISource, AutonomousSystem, EventStatus, EventStatusType, RawEvent, Sensor, SourceType, Statistics
 from greedybear.utils import is_ip_address, is_valid_domain
 
@@ -294,8 +294,8 @@ def get_greedybear_news() -> list[dict]:
         return cached
 
     try:
-        response = requests.get(RSS_FEED_URL, timeout=5)
-        response.raise_for_status()
+        with HttpClient() as client:
+            response = client.get(RSS_FEED_URL, timeout=5)
         feed = feedparser.parse(response.content)
 
         filtered_entries = sorted(

--- a/greedybear/ntfy.py
+++ b/greedybear/ntfy.py
@@ -1,7 +1,8 @@
 import logging
 
-import requests
 from django.conf import settings
+
+from greedybear.cronjobs.http_client import HttpClient
 
 logger = logging.getLogger(__name__)
 
@@ -19,13 +20,13 @@ def send_ntfy_message(message):
     }
 
     try:
-        response = requests.post(
-            settings.NTFY_URL,
-            data=message.encode("utf-8"),
-            headers=headers,
-            timeout=(1, 2),
-        )
-        response.raise_for_status()
+        with HttpClient() as client:
+            client.post(
+                settings.NTFY_URL,
+                data=message.encode("utf-8"),
+                headers=headers,
+                timeout=(1, 2),
+            )
 
     except Exception:
         logger.exception("Failed to send ntfy message")

--- a/tests/api/views/test_news_view.py
+++ b/tests/api/views/test_news_view.py
@@ -125,7 +125,7 @@ class NewsTestCase(CustomTestCase):
         self.assertEqual(result1, result2)
         mock_parse.assert_not_called()
 
-    @patch("api.views.utils.requests.get")
+    @patch("api.views.utils.HttpClient.get")
     def test_feed_request_timeout_returns_empty_list(self, mock_get):
         mock_get.side_effect = requests.Timeout()
 

--- a/tests/test_ntfy.py
+++ b/tests/test_ntfy.py
@@ -1,5 +1,6 @@
 from unittest.mock import MagicMock, patch
 
+import requests
 from django.test import override_settings
 
 from greedybear.ntfy import send_ntfy_message
@@ -14,14 +15,12 @@ TEST_LOGGING = {
 @override_settings(LOGGING=TEST_LOGGING)
 class SendNtfyMessageTests(CustomTestCase):
     @override_settings(NTFY_URL="https://ntfy.sh/greedybear")
-    @patch("greedybear.ntfy.requests.post")
+    @patch("greedybear.ntfy.HttpClient.post")
     @patch("greedybear.ntfy.logger")
     def test_happy_path_successful_post(self, mock_logger, mock_post):
         message = "Something went wrong"
 
-        mock_response = MagicMock()
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        mock_post.return_value = MagicMock()
 
         send_ntfy_message(message)
 
@@ -39,13 +38,11 @@ class SendNtfyMessageTests(CustomTestCase):
         mock_logger.exception.assert_not_called()
 
     @override_settings(NTFY_URL="https://ntfy.sh/greedybear")
-    @patch("greedybear.ntfy.requests.post")
+    @patch("greedybear.ntfy.HttpClient.post")
     def test_happy_path_non_ascii_message(self, mock_post):
         message = "⚠️ Über-alert"
 
-        mock_response = MagicMock()
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        mock_post.return_value = MagicMock()
 
         send_ntfy_message(message)
 
@@ -53,7 +50,7 @@ class SendNtfyMessageTests(CustomTestCase):
         self.assertEqual(kwargs["data"], message.encode("utf-8"))
 
     @override_settings(NTFY_URL="")
-    @patch("greedybear.ntfy.requests.post")
+    @patch("greedybear.ntfy.HttpClient.post")
     @patch("greedybear.ntfy.logger")
     def test_no_url_configured_logs_warning_and_skips_post(self, mock_logger, mock_post):
         send_ntfy_message("anything")
@@ -62,21 +59,17 @@ class SendNtfyMessageTests(CustomTestCase):
         mock_logger.warning.assert_called_once()
 
     @override_settings(NTFY_URL="https://ntfy.sh/greedybear")
-    @patch("greedybear.ntfy.requests.post")
+    @patch("greedybear.ntfy.HttpClient.post")
     @patch("greedybear.ntfy.logger")
     def test_http_error_logged_but_not_raised(self, mock_logger, mock_post):
-        error = Exception("HTTP 500")
-
-        mock_response = MagicMock()
-        mock_response.raise_for_status.side_effect = error
-        mock_post.return_value = mock_response
+        mock_post.side_effect = requests.HTTPError("HTTP 500")
 
         send_ntfy_message("msg")
 
         mock_logger.exception.assert_called_once()
 
     @override_settings(NTFY_URL="https://ntfy.sh/greedybear")
-    @patch("greedybear.ntfy.requests.post")
+    @patch("greedybear.ntfy.HttpClient.post")
     @patch("greedybear.ntfy.logger")
     def test_network_error_logged_but_not_raised(self, mock_logger, mock_post):
         error = TimeoutError("timeout")


### PR DESCRIPTION
## Description

This PR is the final batch of the `#1214` migration, completing the full standardisation of all HTTP fetchers in the project.

It migrates the two remaining raw `requests` calls — `send_ntfy_message()` in `greedybear/ntfy.py` and `get_greedybear_news()` in `api/views/utils.py` — to the centralised `HttpClient` wrapper introduced in #1253.

Key details:
- `greedybear/ntfy.py`: Migrated `requests.post()` → `HttpClient().post()`. The tuple timeout `(1, 2)` is preserved and passed through unchanged. The existing broad `except Exception` swallow-and-log behaviour is preserved since ntfy failures must never crash the application.
- `api/views/utils.py`: Migrated `requests.get()` → `HttpClient().get()`. Same error-swallowing behaviour preserved for RSS feed failures.
- Manual `raise_for_status()` calls removed from both files — `HttpClient` handles this automatically.

With this PR, **zero raw `requests.get`/`requests.post` calls remain in the entire codebase**, and the `#1214` migration can be closed.

## Related issues

- Closes #1214
- Depends on #1253, #1254, #1309, and #1421

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

## Checklist

### Formalities

- [x] I have read and understood the rules about how to Contribute to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop` (via the wrapper branch).
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behaviour that is described in the docs. If so, I also included an update to the wiki in the description of this PR.
- [x] Linter (Ruff) gave 0 errors. If you have correctly installed pre-commit, it runs these checks and makes these adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

_N/A — no GUI changes in this PR._
