### PR TITLE
[Dashboard Modularization] Add configEditor enabling drag and drop. Closes #1425.

### DIFF
--- a/frontend/src/components/Routes.jsx
+++ b/frontend/src/components/Routes.jsx
@@ -18,9 +18,7 @@ const Feeds = React.lazy(() => import("./feeds/Feeds"));
 const ChangePassword = React.lazy(
   () => import("./me/changepassword/ChangePassword"),
 );
-const ConfigEditor = React.lazy(
-  () => import("./dashboard/ConfigEditor"),
-);
+const ConfigEditor = React.lazy(() => import("./dashboard/ConfigEditor"));
 
 // public components
 const publicRoutesLazy = [

--- a/frontend/src/components/Routes.jsx
+++ b/frontend/src/components/Routes.jsx
@@ -3,6 +3,7 @@ import { FallBackLoading } from "@greedybear/gb-ui";
 
 import IfAuthRedirectGuard from "../wrappers/ifAuthRedirectGuard";
 import AuthGuard from "../wrappers/AuthGuard";
+import SuperuserGuard from "../wrappers/SuperuserGuard";
 import ErrorBoundary from "../wrappers/ErrorBoundary";
 
 const Home = React.lazy(() => import("./home/Home"));
@@ -16,6 +17,9 @@ const Sessions = React.lazy(() => import("./me/sessions/Sessions"));
 const Feeds = React.lazy(() => import("./feeds/Feeds"));
 const ChangePassword = React.lazy(
   () => import("./me/changepassword/ChangePassword"),
+);
+const ConfigEditor = React.lazy(
+  () => import("./dashboard/ConfigEditor"),
 );
 
 // public components
@@ -104,6 +108,16 @@ const authRoutesLazy = [
   {
     path: "/me/change-password",
     element: <ChangePassword />,
+    withErrorBoundary: true,
+  },
+  /* Dashboard Config */
+  {
+    path: "/dashboard/config",
+    element: (
+      <SuperuserGuard>
+        <ConfigEditor />
+      </SuperuserGuard>
+    ),
     withErrorBoundary: true,
   },
 ].map((r) => ({

--- a/frontend/src/components/dashboard/ConfigEditor.jsx
+++ b/frontend/src/components/dashboard/ConfigEditor.jsx
@@ -1,0 +1,344 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { Container, Badge, Dropdown, DropdownToggle, DropdownMenu, DropdownItem, Row, Col } from "reactstrap";
+import { Responsive, useContainerWidth } from "react-grid-layout";
+import {
+  MdArrowBack,
+  MdAdd,
+  MdClose,
+  MdSave,
+  MdRestartAlt,
+} from "react-icons/md";
+import { useShallow } from "zustand/shallow";
+
+import "react-grid-layout/css/styles.css";
+import "react-resizable/css/styles.css";
+
+import widgetRegistry from "./widgetRegistry";
+import WidgetWrapper from "./WidgetWrapper";
+import useDashboardStore from "../../stores/useDashboardStore";
+
+const DEFAULT_H = 9;
+
+function buildLayoutEntry(id, currentLgLayout, w = 12) {
+  const maxY = currentLgLayout.reduce(
+    (acc, item) => Math.max(acc, item.y + item.h),
+    0,
+  );
+  return { i: id, x: 0, y: maxY, w, h: 9, static: false };
+}
+
+
+// ---------------------------------------------------------------------------
+// EditableWidgetCard
+// Renders the real widget. A small floating X button sits in the top-right
+// corner for removal. The whole card is the drag target.
+// ---------------------------------------------------------------------------
+function EditableWidgetCard({ cfg, definition, onRemove }) {
+  const { component: WidgetComponent, displayName, defaultProps: registryDefaultProps } =
+    definition;
+  const mergedProps = { ...(registryDefaultProps ?? {}), ...(cfg.props ?? {}) };
+
+  return (
+    <div style={{ height: "100%", position: "relative" }}>
+      <WidgetWrapper
+        id={cfg.id}
+        header={displayName}
+        fillHeight
+      >
+        <WidgetComponent {...mergedProps} />
+      </WidgetWrapper>
+
+      {/* remove button */}
+      <button
+        title="Remove widget"
+        onMouseDown={(e) => e.stopPropagation()}
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove(cfg.id);
+        }}
+        style={{
+          position: "absolute",
+          top: 6,
+          right: 8,
+          zIndex: 10,
+          background: "rgba(224,82,82,0.85)",
+          border: "none",
+          borderRadius: "50%",
+          width: 22,
+          height: 22,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          cursor: "pointer",
+          color: "#fff",
+          fontSize: "0.85rem",
+          boxShadow: "0 1px 4px rgba(0,0,0,0.4)",
+        }}
+      >
+        <MdClose />
+      </button>
+    </div>
+  );
+}
+
+function AddWidgetDropdown({ availableWidgets, addedTypes, onAdd }) {
+  const [open, setOpen] = React.useState(false);
+  const unadded = availableWidgets.filter(([type]) => !addedTypes.has(type));
+
+  return (
+    <Dropdown isOpen={open} toggle={() => setOpen((o) => !o)}>
+      <DropdownToggle
+        id="config-add-widget-btn"
+        className="btn btn-sm btn-outline-primary d-flex align-items-center gap-1"
+        tag="button"
+        disabled={unadded.length === 0}
+        style={{ opacity: 1 }}
+        title={unadded.length === 0 ? "All widgets are already on the dashboard" : "Add a widget"}
+      >
+        <MdAdd />
+        Add Widget
+      </DropdownToggle>
+      <DropdownMenu end>
+        {unadded.map(([type, def]) => (
+          <DropdownItem
+            key={type}
+            onClick={() => {
+              onAdd(type);
+              setOpen(false);
+            }}
+          >
+            {def.displayName}
+          </DropdownItem>
+        ))}
+      </DropdownMenu>
+    </Dropdown>
+  );
+}
+
+export default function ConfigEditor() {
+  console.debug("ConfigEditor rendered!");
+
+  const {
+    layouts,
+    widgetConfigs,
+    isDirty,
+    setLayouts,
+    setWidgetConfigs,
+    save,
+    resetToDefault,
+  } = useDashboardStore(
+    useShallow((s) => ({
+      layouts: s.layouts,
+      widgetConfigs: s.widgetConfigs,
+      isDirty: s.isDirty,
+      setLayouts: s.setLayouts,
+      setWidgetConfigs: s.setWidgetConfigs,
+      save: s.save,
+      resetToDefault: s.resetToDefault,
+    })),
+  );
+
+  const { width, containerRef } = useContainerWidth();
+
+  const gridConfigs = React.useMemo(
+    () => widgetConfigs.filter((cfg) => !cfg.noGrid),
+    [widgetConfigs],
+  );
+
+  const noGridConfigs = React.useMemo(
+    () => widgetConfigs.filter((cfg) => cfg.noGrid),
+    [widgetConfigs],
+  );
+
+  const addedTypes = React.useMemo(
+    () => new Set(gridConfigs.map((cfg) => cfg.type)),
+    [gridConfigs],
+  );
+
+  // Widget types that are already rendered above the grid (noGrid: true).
+  const noGridTypes = React.useMemo(
+    () => new Set(widgetConfigs.filter((cfg) => cfg.noGrid).map((cfg) => cfg.type)),
+    [widgetConfigs],
+  );
+
+  // All grid-capable widgets
+  const availableWidgets = React.useMemo(
+    () =>
+      [...widgetRegistry.entries()].filter(
+        ([type, def]) => def.fillHeight !== undefined && !noGridTypes.has(type),
+      ),
+    [noGridTypes],
+  );
+
+
+  const handleAdd = React.useCallback(
+    (type) => {
+      const def = widgetRegistry.get(type);
+      if (!def) return;
+      const id = type;
+      const nextConfigs = [...widgetConfigs, { type, id, noGrid: false }];
+      setWidgetConfigs(nextConfigs);
+      const lgEntry = buildLayoutEntry(id, layouts.lg ?? [], 12);
+      setLayouts({
+        lg: [...(layouts.lg ?? []), lgEntry],
+        md: [...(layouts.md ?? []), { ...lgEntry, w: 12 }],
+        sm: [...(layouts.sm ?? []), { ...lgEntry, w: 12 }],
+      });
+    },
+    [widgetConfigs, layouts, setWidgetConfigs, setLayouts],
+  );
+
+  const handleRemove = React.useCallback(
+    (id) => {
+      setWidgetConfigs(widgetConfigs.filter((cfg) => cfg.id !== id));
+      setLayouts({
+        lg: (layouts.lg ?? []).filter((item) => item.i !== id),
+        md: (layouts.md ?? []).filter((item) => item.i !== id),
+        sm: (layouts.sm ?? []).filter((item) => item.i !== id),
+      });
+    },
+    [widgetConfigs, layouts, setWidgetConfigs, setLayouts],
+  );
+
+
+  const handleLayoutChange = React.useCallback(
+    (_currentLayout, allLayouts) => {
+      setLayouts({
+        lg: allLayouts.lg ?? layouts.lg,
+        md: allLayouts.md ?? layouts.md,
+        sm: allLayouts.sm ?? layouts.sm,
+      });
+    },
+    [setLayouts, layouts],
+  );
+
+  const handleReset = React.useCallback(() => {
+    if (window.confirm("Reset dashboard to defaults? All changes will be lost.")) {
+      resetToDefault();
+    }
+  }, [resetToDefault]);
+
+  const editableLayouts = React.useMemo(() => {
+    const makeEditable = (arr) =>
+      (arr ?? []).map((item) => ({ ...item, static: false }));
+    return {
+      lg: makeEditable(layouts.lg),
+      md: makeEditable(layouts.md),
+      sm: makeEditable(layouts.sm),
+    };
+  }, [layouts]);
+
+  return (
+    <Container fluid id="ConfigEditor" className="py-3">
+      <div className="d-flex align-items-center flex-wrap gap-2 mb-3">
+        <Link
+          to="/dashboard"
+          className="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1"
+          id="config-back-btn"
+        >
+          <MdArrowBack />
+          Dashboard
+        </Link>
+
+        <h5 className="fw-bold mb-0 ms-1">Dashboard Config</h5>
+
+        {isDirty && (
+          <Badge color="warning" className="align-self-center">
+            Unsaved changes
+          </Badge>
+        )}
+
+        <div className="ms-auto d-flex gap-2">
+          <AddWidgetDropdown
+            availableWidgets={availableWidgets}
+            addedTypes={addedTypes}
+            onAdd={handleAdd}
+          />
+          <button
+            id="config-reset-btn"
+            className="btn btn-sm btn-outline-danger d-flex align-items-center gap-1"
+            onClick={handleReset}
+            title="Reset to defaults"
+          >
+            <MdRestartAlt />
+            Reset
+          </button>
+          <button
+            id="config-save-btn"
+            className="btn btn-sm btn-primary d-flex align-items-center gap-1"
+            onClick={save}
+            disabled={!isDirty}
+            title="Save layout"
+          >
+            <MdSave />
+            Save
+          </button>
+        </div>
+      </div>
+
+      {noGridConfigs.map((cfg, idx) => {
+        const definition = widgetRegistry.get(cfg.type);
+        if (!definition) return null;
+        const { component: WidgetComponent, displayName, defaultHeight, defaultProps: registryDefaultProps } = definition;
+        const mergedProps = { ...(registryDefaultProps ?? {}), ...(cfg.props ?? {}) };
+        return (
+          <Row key={cfg.id} className={`${idx > 0 ? "mt-4 " : ""}mb-4`}>
+            <Col md={12}>
+              <WidgetWrapper id={cfg.id} header={displayName} minHeight={defaultHeight}>
+                <WidgetComponent {...mergedProps} />
+              </WidgetWrapper>
+            </Col>
+          </Row>
+        );
+      })}
+
+      <p className="small text-muted mb-3" style={{ fontSize: 12 }}>
+        Drag any widget to reorder · drag the bottom-right corner to resize
+      </p>
+
+      <div ref={containerRef}>
+        {gridConfigs.length === 0 ? (
+          <div
+            className="d-flex align-items-center justify-content-center text-muted"
+            style={{
+              minHeight: 200,
+              border: "2px dashed rgba(99,102,241,0.25)",
+              borderRadius: 10,
+            }}
+          >
+            <span className="small">
+              No widgets — use <strong>Add Widget</strong> above to add one.
+            </span>
+          </div>
+        ) : (
+          <Responsive
+            width={width || 800}
+            layouts={editableLayouts}
+            breakpoints={{ lg: 992, md: 768, sm: 576, xs: 480, xxs: 0 }}
+            cols={{ lg: 12, md: 12, sm: 12, xs: 1, xxs: 1 }}
+            rowHeight={30}
+            margin={[16, 16]}
+            containerPadding={[0, 0]}
+            onLayoutChange={handleLayoutChange}
+            resizeHandles={["se"]}
+          >
+            {gridConfigs.map((cfg) => {
+              const definition = widgetRegistry.get(cfg.type);
+              if (!definition) return null;
+              return (
+                <div key={cfg.id} style={{ height: "100%", overflow: "hidden" }}>
+                  <EditableWidgetCard
+                    cfg={cfg}
+                    definition={definition}
+                    onRemove={handleRemove}
+                  />
+                </div>
+              );
+            })}
+          </Responsive>
+        )}
+      </div>
+    </Container>
+  );
+}

--- a/frontend/src/components/dashboard/ConfigEditor.jsx
+++ b/frontend/src/components/dashboard/ConfigEditor.jsx
@@ -110,7 +110,14 @@ function AddWidgetDropdown({ availableWidgets, addedTypes, onAdd }) {
         <MdAdd />
         Add Widget
       </DropdownToggle>
-      <DropdownMenu end>
+      <DropdownMenu
+        end
+        style={{
+          background: "#1e1e2e",
+          border: "1px solid rgba(99,102,241,0.35)",
+          boxShadow: "0 4px 16px rgba(0,0,0,0.5)",
+        }}
+      >
         {unadded.map(([type, def]) => (
           <DropdownItem
             key={type}

--- a/frontend/src/components/dashboard/ConfigEditor.jsx
+++ b/frontend/src/components/dashboard/ConfigEditor.jsx
@@ -27,8 +27,6 @@ import widgetRegistry from "./widgetRegistry";
 import WidgetWrapper from "./WidgetWrapper";
 import useDashboardStore from "../../stores/useDashboardStore";
 
-const DEFAULT_H = 9;
-
 function buildLayoutEntry(id, currentLgLayout, w = 12) {
   const maxY = currentLgLayout.reduce(
     (acc, item) => Math.max(acc, item.y + item.h),

--- a/frontend/src/components/dashboard/ConfigEditor.jsx
+++ b/frontend/src/components/dashboard/ConfigEditor.jsx
@@ -1,6 +1,15 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Container, Badge, Dropdown, DropdownToggle, DropdownMenu, DropdownItem, Row, Col } from "reactstrap";
+import {
+  Container,
+  Badge,
+  Dropdown,
+  DropdownToggle,
+  DropdownMenu,
+  DropdownItem,
+  Row,
+  Col,
+} from "reactstrap";
 import { Responsive, useContainerWidth } from "react-grid-layout";
 import {
   MdArrowBack,
@@ -28,24 +37,22 @@ function buildLayoutEntry(id, currentLgLayout, w = 12) {
   return { i: id, x: 0, y: maxY, w, h: 9, static: false };
 }
 
-
 // ---------------------------------------------------------------------------
 // EditableWidgetCard
 // Renders the real widget. A small floating X button sits in the top-right
 // corner for removal. The whole card is the drag target.
 // ---------------------------------------------------------------------------
 function EditableWidgetCard({ cfg, definition, onRemove }) {
-  const { component: WidgetComponent, displayName, defaultProps: registryDefaultProps } =
-    definition;
+  const {
+    component: WidgetComponent,
+    displayName,
+    defaultProps: registryDefaultProps,
+  } = definition;
   const mergedProps = { ...(registryDefaultProps ?? {}), ...(cfg.props ?? {}) };
 
   return (
     <div style={{ height: "100%", position: "relative" }}>
-      <WidgetWrapper
-        id={cfg.id}
-        header={displayName}
-        fillHeight
-      >
+      <WidgetWrapper id={cfg.id} header={displayName} fillHeight>
         <WidgetComponent {...mergedProps} />
       </WidgetWrapper>
 
@@ -94,7 +101,11 @@ function AddWidgetDropdown({ availableWidgets, addedTypes, onAdd }) {
         tag="button"
         disabled={unadded.length === 0}
         style={{ opacity: 1 }}
-        title={unadded.length === 0 ? "All widgets are already on the dashboard" : "Add a widget"}
+        title={
+          unadded.length === 0
+            ? "All widgets are already on the dashboard"
+            : "Add a widget"
+        }
       >
         <MdAdd />
         Add Widget
@@ -158,7 +169,8 @@ export default function ConfigEditor() {
 
   // Widget types that are already rendered above the grid (noGrid: true).
   const noGridTypes = React.useMemo(
-    () => new Set(widgetConfigs.filter((cfg) => cfg.noGrid).map((cfg) => cfg.type)),
+    () =>
+      new Set(widgetConfigs.filter((cfg) => cfg.noGrid).map((cfg) => cfg.type)),
     [widgetConfigs],
   );
 
@@ -170,7 +182,6 @@ export default function ConfigEditor() {
       ),
     [noGridTypes],
   );
-
 
   const handleAdd = React.useCallback(
     (type) => {
@@ -201,7 +212,6 @@ export default function ConfigEditor() {
     [widgetConfigs, layouts, setWidgetConfigs, setLayouts],
   );
 
-
   const handleLayoutChange = React.useCallback(
     (_currentLayout, allLayouts) => {
       setLayouts({
@@ -214,7 +224,9 @@ export default function ConfigEditor() {
   );
 
   const handleReset = React.useCallback(() => {
-    if (window.confirm("Reset dashboard to defaults? All changes will be lost.")) {
+    if (
+      window.confirm("Reset dashboard to defaults? All changes will be lost.")
+    ) {
       resetToDefault();
     }
   }, [resetToDefault]);
@@ -280,12 +292,24 @@ export default function ConfigEditor() {
       {noGridConfigs.map((cfg, idx) => {
         const definition = widgetRegistry.get(cfg.type);
         if (!definition) return null;
-        const { component: WidgetComponent, displayName, defaultHeight, defaultProps: registryDefaultProps } = definition;
-        const mergedProps = { ...(registryDefaultProps ?? {}), ...(cfg.props ?? {}) };
+        const {
+          component: WidgetComponent,
+          displayName,
+          defaultHeight,
+          defaultProps: registryDefaultProps,
+        } = definition;
+        const mergedProps = {
+          ...(registryDefaultProps ?? {}),
+          ...(cfg.props ?? {}),
+        };
         return (
           <Row key={cfg.id} className={`${idx > 0 ? "mt-4 " : ""}mb-4`}>
             <Col md={12}>
-              <WidgetWrapper id={cfg.id} header={displayName} minHeight={defaultHeight}>
+              <WidgetWrapper
+                id={cfg.id}
+                header={displayName}
+                minHeight={defaultHeight}
+              >
                 <WidgetComponent {...mergedProps} />
               </WidgetWrapper>
             </Col>
@@ -327,7 +351,10 @@ export default function ConfigEditor() {
               const definition = widgetRegistry.get(cfg.type);
               if (!definition) return null;
               return (
-                <div key={cfg.id} style={{ height: "100%", overflow: "hidden" }}>
+                <div
+                  key={cfg.id}
+                  style={{ height: "100%", overflow: "hidden" }}
+                >
                   <EditableWidgetCard
                     cfg={cfg}
                     definition={definition}

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -14,9 +14,7 @@ function Dashboard() {
   console.debug("Dashboard rendered!");
   const { range, onTimeIntervalChange } = useTimePickerStore();
 
-  const isSuperuser = useAuthStore(
-    React.useCallback((s) => s.isSuperuser, []),
-  );
+  const isSuperuser = useAuthStore(React.useCallback((s) => s.isSuperuser, []));
 
   const { widgetConfigs, layouts, savedVersion } = useDashboardStore(
     useShallow((s) => ({
@@ -27,7 +25,8 @@ function Dashboard() {
   );
 
   const staticLayouts = React.useMemo(() => {
-    const freeze = (arr) => (arr ?? []).map((item) => ({ ...item, static: true }));
+    const freeze = (arr) =>
+      (arr ?? []).map((item) => ({ ...item, static: true }));
     return {
       lg: freeze(layouts.lg),
       md: freeze(layouts.md),

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -1,30 +1,69 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import { Container } from "reactstrap";
+import { MdSettings } from "react-icons/md";
+import { useShallow } from "zustand/shallow";
 
 import { ElasticTimePicker, useTimePickerStore } from "@greedybear/gb-ui";
 
 import DashboardRenderer from "./DashboardRenderer";
-import { WIDGET_CONFIGS, DASHBOARD_LAYOUTS } from "./defaultDashboardConfig";
+import useDashboardStore from "../../stores/useDashboardStore";
+import { useAuthStore } from "../../stores";
 
 function Dashboard() {
   console.debug("Dashboard rendered!");
   const { range, onTimeIntervalChange } = useTimePickerStore();
 
+  const isSuperuser = useAuthStore(
+    React.useCallback((s) => s.isSuperuser, []),
+  );
+
+  const { widgetConfigs, layouts, savedVersion } = useDashboardStore(
+    useShallow((s) => ({
+      widgetConfigs: s.widgetConfigs,
+      layouts: s.layouts,
+      savedVersion: s.savedVersion,
+    })),
+  );
+
+  const staticLayouts = React.useMemo(() => {
+    const freeze = (arr) => (arr ?? []).map((item) => ({ ...item, static: true }));
+    return {
+      lg: freeze(layouts.lg),
+      md: freeze(layouts.md),
+      sm: freeze(layouts.sm),
+    };
+  }, [layouts]);
+
   return (
     <Container fluid id="Dashboard">
       <div className="g-0 d-flex align-items-baseline flex-column flex-lg-row mb-2">
         <h3 className="fw-bold">Dashboard</h3>
-        <ElasticTimePicker
-          className="ms-auto"
-          size="sm"
-          defaultSelected={range}
-          onChange={onTimeIntervalChange}
-        />
+
+        <div className="ms-auto d-flex align-items-center gap-2">
+          {isSuperuser && (
+            <Link
+              to="/dashboard/config"
+              id="dashboard-configure-btn"
+              className="btn btn-sm btn-outline-secondary d-flex align-items-center gap-1"
+              title="Configure dashboard layout"
+            >
+              <MdSettings />
+              Configure
+            </Link>
+          )}
+          <ElasticTimePicker
+            size="sm"
+            defaultSelected={range}
+            onChange={onTimeIntervalChange}
+          />
+        </div>
       </div>
 
       <DashboardRenderer
-        widgetConfigs={WIDGET_CONFIGS}
-        layouts={DASHBOARD_LAYOUTS}
+        key={savedVersion}
+        widgetConfigs={widgetConfigs}
+        layouts={staticLayouts}
       />
     </Container>
   );

--- a/frontend/src/layouts/AppHeader.jsx
+++ b/frontend/src/layouts/AppHeader.jsx
@@ -97,7 +97,6 @@ function AppHeader() {
                 <span className="ms-1">Feeds</span>
               </NavLink>
             </NavItem>
-
           </Nav>
           {/* Navbar Right Side */}
           <Nav navbar className="ms-auto d-flex align-items-center">

--- a/frontend/src/layouts/AppHeader.jsx
+++ b/frontend/src/layouts/AppHeader.jsx
@@ -8,7 +8,7 @@ import {
   NavbarToggler,
 } from "reactstrap";
 import { NavLink as RRNavLink } from "react-router-dom";
-import { MdHome, MdOutlineFeed, MdDashboard, MdSettings } from "react-icons/md";
+import { MdHome, MdOutlineFeed, MdDashboard } from "react-icons/md";
 import { RiBookReadFill } from "react-icons/ri";
 
 // lib
@@ -67,9 +67,6 @@ function AppHeader() {
   const isAuthenticated = useAuthStore(
     React.useCallback((s) => s.isAuthenticated, []),
   );
-  const isSuperuser = useAuthStore(
-    React.useCallback((s) => s.isSuperuser, []),
-  );
 
   return (
     <header className="fixed-top">
@@ -100,18 +97,7 @@ function AppHeader() {
                 <span className="ms-1">Feeds</span>
               </NavLink>
             </NavItem>
-            {isSuperuser && (
-              <NavItem>
-                <NavLink
-                  id="nav-dashboard-config"
-                  className="d-flex-start-center"
-                  to="/dashboard/config"
-                >
-                  <MdSettings />
-                  <span className="ms-1">Config</span>
-                </NavLink>
-              </NavItem>
-            )}
+
           </Nav>
           {/* Navbar Right Side */}
           <Nav navbar className="ms-auto d-flex align-items-center">

--- a/frontend/src/layouts/AppHeader.jsx
+++ b/frontend/src/layouts/AppHeader.jsx
@@ -8,7 +8,7 @@ import {
   NavbarToggler,
 } from "reactstrap";
 import { NavLink as RRNavLink } from "react-router-dom";
-import { MdHome, MdOutlineFeed, MdDashboard } from "react-icons/md";
+import { MdHome, MdOutlineFeed, MdDashboard, MdSettings } from "react-icons/md";
 import { RiBookReadFill } from "react-icons/ri";
 
 // lib
@@ -67,6 +67,9 @@ function AppHeader() {
   const isAuthenticated = useAuthStore(
     React.useCallback((s) => s.isAuthenticated, []),
   );
+  const isSuperuser = useAuthStore(
+    React.useCallback((s) => s.isSuperuser, []),
+  );
 
   return (
     <header className="fixed-top">
@@ -97,6 +100,18 @@ function AppHeader() {
                 <span className="ms-1">Feeds</span>
               </NavLink>
             </NavItem>
+            {isSuperuser && (
+              <NavItem>
+                <NavLink
+                  id="nav-dashboard-config"
+                  className="d-flex-start-center"
+                  to="/dashboard/config"
+                >
+                  <MdSettings />
+                  <span className="ms-1">Config</span>
+                </NavLink>
+              </NavItem>
+            )}
           </Nav>
           {/* Navbar Right Side */}
           <Nav navbar className="ms-auto d-flex align-items-center">

--- a/frontend/src/stores/index.js
+++ b/frontend/src/stores/index.js
@@ -1,1 +1,2 @@
 export { default as useAuthStore } from "./useAuthStore";
+export { default as useDashboardStore } from "./useDashboardStore";

--- a/frontend/src/stores/useDashboardStore.js
+++ b/frontend/src/stores/useDashboardStore.js
@@ -11,7 +11,7 @@ import {
  *
  * Holds the live dashboard layout state that the ConfigEditor mutates.
  * Persisted to localStorage.
- * 
+ *
  * Shape:
  *   layouts       {object}  react-grid-layout layouts object (all breakpoints)
  *   widgetConfigs {Array}   ordered list of { type, id, noGrid? }
@@ -32,7 +32,8 @@ const useDashboardStore = create(
       setLayouts: (layouts) => set({ layouts, isDirty: true }),
 
       /** Called when admin adds or removes a widget */
-      setWidgetConfigs: (widgetConfigs) => set({ widgetConfigs, isDirty: true }),
+      setWidgetConfigs: (widgetConfigs) =>
+        set({ widgetConfigs, isDirty: true }),
 
       /**
        * Commit the current layout.
@@ -40,7 +41,8 @@ const useDashboardStore = create(
        * (via React key), which forces react-grid-layout to re-initialize its
        * internal layout state from the updated props.
        */
-      save: () => set((s) => ({ isDirty: false, savedVersion: s.savedVersion + 1 })),
+      save: () =>
+        set((s) => ({ isDirty: false, savedVersion: s.savedVersion + 1 })),
 
       /** Reset to the hardcoded defaults */
       resetToDefault: () =>

--- a/frontend/src/stores/useDashboardStore.js
+++ b/frontend/src/stores/useDashboardStore.js
@@ -1,0 +1,60 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+import {
+  WIDGET_CONFIGS,
+  DASHBOARD_LAYOUTS,
+} from "../components/dashboard/defaultDashboardConfig";
+
+/**
+ * useDashboardStore
+ *
+ * Holds the live dashboard layout state that the ConfigEditor mutates.
+ * Persisted to localStorage.
+ * 
+ * Shape:
+ *   layouts       {object}  react-grid-layout layouts object (all breakpoints)
+ *   widgetConfigs {Array}   ordered list of { type, id, noGrid? }
+ *   isDirty       {boolean} true when there are unsaved changes
+ *   savedVersion  {number}  incremented on every save(); used as a React key on
+ *                           DashboardRenderer to force a clean RGL remount so the
+ *                           new positions are always picked up from props.
+ */
+const useDashboardStore = create(
+  persist(
+    (set) => ({
+      layouts: DASHBOARD_LAYOUTS,
+      widgetConfigs: WIDGET_CONFIGS,
+      isDirty: false,
+      savedVersion: 0,
+
+      /** Called by RGL onLayoutChange, keeps layouts in sync with drag/resize */
+      setLayouts: (layouts) => set({ layouts, isDirty: true }),
+
+      /** Called when admin adds or removes a widget */
+      setWidgetConfigs: (widgetConfigs) => set({ widgetConfigs, isDirty: true }),
+
+      /**
+       * Commit the current layout.
+       * Incrementing savedVersion causes Dashboard to remount DashboardRenderer
+       * (via React key), which forces react-grid-layout to re-initialize its
+       * internal layout state from the updated props.
+       */
+      save: () => set((s) => ({ isDirty: false, savedVersion: s.savedVersion + 1 })),
+
+      /** Reset to the hardcoded defaults */
+      resetToDefault: () =>
+        set((s) => ({
+          layouts: DASHBOARD_LAYOUTS,
+          widgetConfigs: WIDGET_CONFIGS,
+          isDirty: false,
+          savedVersion: s.savedVersion + 1,
+        })),
+    }),
+    {
+      name: "greedybear-dashboard-config",
+    },
+  ),
+);
+
+export default useDashboardStore;

--- a/frontend/src/wrappers/SuperuserGuard.jsx
+++ b/frontend/src/wrappers/SuperuserGuard.jsx
@@ -12,9 +12,7 @@ import { useAuthStore } from "../stores";
  * it is already unusual.
  */
 export default function SuperuserGuard({ children }) {
-  const isSuperuser = useAuthStore(
-    React.useCallback((s) => s.isSuperuser, []),
-  );
+  const isSuperuser = useAuthStore(React.useCallback((s) => s.isSuperuser, []));
 
   if (!isSuperuser) {
     return (

--- a/frontend/src/wrappers/SuperuserGuard.jsx
+++ b/frontend/src/wrappers/SuperuserGuard.jsx
@@ -1,0 +1,37 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { useAuthStore } from "../stores";
+
+/**
+ * SuperuserGuard
+ *
+ * Renders children only for superusers. Non-superusers see a 403-style
+ * message in place of the protected content. The user is NOT redirected
+ * the route is simply not shown in navigation for regular users, so reaching
+ * it is already unusual.
+ */
+export default function SuperuserGuard({ children }) {
+  const isSuperuser = useAuthStore(
+    React.useCallback((s) => s.isSuperuser, []),
+  );
+
+  if (!isSuperuser) {
+    return (
+      <div
+        className="d-flex flex-column align-items-center justify-content-center py-5 text-muted"
+        style={{ minHeight: 300 }}
+      >
+        <span style={{ fontSize: "3rem" }}>🔒</span>
+        <h4 className="mt-3 fw-bold">Access Restricted</h4>
+        <p className="small">This page is only available to superusers.</p>
+      </div>
+    );
+  }
+
+  return children;
+}
+
+SuperuserGuard.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/frontend/tests/components/dashboard/ConfigEditor.test.jsx
+++ b/frontend/tests/components/dashboard/ConfigEditor.test.jsx
@@ -1,0 +1,327 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+
+// Mock react-grid-layout
+vi.mock("react-grid-layout", () => ({
+  Responsive: ({ children }) => <div data-testid="rgl-grid">{children}</div>,
+  useContainerWidth: () => ({ width: 1200, containerRef: { current: null } }),
+}));
+
+// Mock all real widget components to divs
+vi.mock("../../../src/components/dashboard/utils/charts", () => ({
+  FeedsTypesChart: () => <div data-testid="widget-FeedsTypesChart" />,
+  FeedsSourcesChart: () => <div data-testid="widget-FeedsSourcesChart" />,
+  FeedsDownloadsChart: () => <div data-testid="widget-FeedsDownloadsChart" />,
+  EnrichmentSourcesChart: () => <div data-testid="widget-EnrichmentSourcesChart" />,
+  EnrichmentRequestsChart: () => <div data-testid="widget-EnrichmentRequestsChart" />,
+  AttackOriginCountriesChart: () => <div data-testid="widget-AttackOriginCountriesChart" />,
+}));
+
+vi.mock("../../../src/components/dashboard/AttackOriginMap", () => ({
+  default: () => <div data-testid="widget-AttackOriginMap" />,
+}));
+
+vi.mock("../../../src/components/dashboard/EnrichmentLookup", () => ({
+  default: () => <div data-testid="widget-EnrichmentLookup" />,
+}));
+
+vi.mock("axios");
+
+// Mock @greedybear/gb-ui
+vi.mock("@greedybear/gb-ui", async (importOriginal) => {
+  const original = await importOriginal();
+  return {
+    ...original,
+    SmallInfoCard: ({ header, body, style, id }) => (
+      <div data-testid={`card-${id}`} style={style}>
+        <div>{header}</div>
+        <div>{body}</div>
+      </div>
+    ),
+    ElasticTimePicker: () => <div />,
+  };
+});
+
+// Mock useAuthStore
+const mockUseAuthStore = vi.fn();
+vi.mock("../../../src/stores", () => ({
+  useAuthStore: (selector) => mockUseAuthStore(selector),
+}));
+
+// Import store and reset helpers
+import useDashboardStore from "../../../src/stores/useDashboardStore";
+import {
+  WIDGET_CONFIGS,
+  DASHBOARD_LAYOUTS,
+} from "../../../src/components/dashboard/defaultDashboardConfig";
+
+function resetStore() {
+  useDashboardStore.setState({
+    layouts: DASHBOARD_LAYOUTS,
+    widgetConfigs: WIDGET_CONFIGS,
+    isDirty: false,
+    savedVersion: 0,
+  });
+}
+
+import ConfigEditor from "../../../src/components/dashboard/ConfigEditor";
+
+// Render helper
+function renderEditor() {
+  return render(
+    <MemoryRouter>
+      <ConfigEditor />
+    </MemoryRouter>,
+  );
+}
+
+describe("ConfigEditor", () => {
+  beforeEach(() => {
+    resetStore();
+    mockUseAuthStore.mockImplementation((selector) =>
+      selector({ isSuperuser: true }),
+    );
+  });
+
+  describe("structural rendering", () => {
+    test("renders the page title", () => {
+      renderEditor();
+      expect(screen.getByText("Dashboard Config")).toBeInTheDocument();
+    });
+
+    test("renders a back-to-dashboard link", () => {
+      renderEditor();
+      expect(screen.getByRole("link", { name: /dashboard/i })).toBeInTheDocument();
+    });
+
+    test("renders Save and Reset buttons", () => {
+      renderEditor();
+      expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+    });
+
+    test("renders the Add Widget button", () => {
+      renderEditor();
+      expect(
+        screen.getByRole("button", { name: /add widget/i }),
+      ).toBeInTheDocument();
+    });
+
+    test("Save button is disabled when there are no unsaved changes", () => {
+      renderEditor();
+      expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    });
+
+    test("does NOT show 'Unsaved changes' badge initially", () => {
+      renderEditor();
+      expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+    });
+  });
+
+  // Grid widget rendering
+
+  describe("grid widgets", () => {
+    test("renders all default grid widgets inside the RGL grid", () => {
+      renderEditor();
+      const grid = screen.getByTestId("rgl-grid");
+      // Default config has 7 widgets: 1 noGrid + 6 in grid
+      // The grid should contain 6 widget card headers (displayNames)
+      expect(within(grid).getByText("Feeds: Types")).toBeInTheDocument();
+      expect(within(grid).getByText("Feeds: Sources")).toBeInTheDocument();
+      expect(within(grid).getByText("Feeds: Downloads")).toBeInTheDocument();
+      expect(within(grid).getByText("Enrichment Service: Sources")).toBeInTheDocument();
+      expect(within(grid).getByText("Enrichment Service: Requests")).toBeInTheDocument();
+      expect(within(grid).getByText("Attack Origins: World Map")).toBeInTheDocument();
+      expect(within(grid).getByText("Attack Origins: Top Countries")).toBeInTheDocument();
+    });
+
+    test("renders a remove (✕) button for each grid widget", () => {
+      renderEditor();
+      const grid = screen.getByTestId("rgl-grid");
+      const removeButtons = within(grid).getAllByTitle("Remove widget");
+      // 7 grid widgets in default config
+      expect(removeButtons).toHaveLength(7);
+    });
+  });
+
+  // noGrid widget rendering
+
+  describe("noGrid widgets", () => {
+    test("renders the noGrid widget (EnrichmentLookup) above the grid", () => {
+      renderEditor();
+      const grid = screen.getByTestId("rgl-grid");
+      // The noGrid widget's card header should exist on the page...
+      expect(screen.getByText("Enrichment Lookup")).toBeInTheDocument();
+      // ...but NOT inside the RGL grid
+      expect(within(grid).queryByText("Enrichment Lookup")).not.toBeInTheDocument();
+    });
+  });
+
+  // Remove widget
+
+  describe("remove widget", () => {
+    test("clicking ✕ removes the widget from the grid", () => {
+      renderEditor();
+      const grid = screen.getByTestId("rgl-grid");
+      expect(within(grid).getByText("Feeds: Types")).toBeInTheDocument();
+
+      // Remove buttons are siblings of the card div (position:relative wrapper),
+      // so we query them directly from the grid and click the first one.
+      const [firstRemoveBtn] = within(grid).getAllByTitle("Remove widget");
+      fireEvent.click(firstRemoveBtn);
+
+      // After removal the grid should have one less widget header
+      expect(within(grid).queryByText("Feeds: Types")).not.toBeInTheDocument();
+    });
+
+    test("removing a widget marks the store as dirty", () => {
+      renderEditor();
+      const grid = screen.getByTestId("rgl-grid");
+      const [firstRemoveBtn] = within(grid).getAllByTitle("Remove widget");
+      fireEvent.click(firstRemoveBtn);
+
+      expect(useDashboardStore.getState().isDirty).toBe(true);
+    });
+
+    test("'Unsaved changes' badge appears after a widget is removed", () => {
+      renderEditor();
+      const grid = screen.getByTestId("rgl-grid");
+      const [firstRemoveBtn] = within(grid).getAllByTitle("Remove widget");
+      fireEvent.click(firstRemoveBtn);
+
+      expect(screen.getByText("Unsaved changes")).toBeInTheDocument();
+    });
+
+    test("Save button becomes enabled after a widget is removed", () => {
+      renderEditor();
+      const grid = screen.getByTestId("rgl-grid");
+      const [firstRemoveBtn] = within(grid).getAllByTitle("Remove widget");
+      fireEvent.click(firstRemoveBtn);
+
+      expect(screen.getByRole("button", { name: /save/i })).not.toBeDisabled();
+    });
+  });
+
+  // Save action
+
+  describe("save", () => {
+    test("clicking Save clears the dirty flag and hides the badge", () => {
+      useDashboardStore.setState({ isDirty: true });
+      renderEditor();
+
+      fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+      expect(useDashboardStore.getState().isDirty).toBe(false);
+      expect(screen.queryByText("Unsaved changes")).not.toBeInTheDocument();
+    });
+
+    test("clicking Save increments savedVersion", () => {
+      useDashboardStore.setState({ isDirty: true });
+      renderEditor();
+
+      const before = useDashboardStore.getState().savedVersion;
+      fireEvent.click(screen.getByRole("button", { name: /save/i }));
+      expect(useDashboardStore.getState().savedVersion).toBe(before + 1);
+    });
+  });
+
+  // Reset action
+
+  describe("reset", () => {
+    test("clicking Reset and confirming restores default widget configs", () => {
+      // Stub window.confirm to auto-approve
+      vi.spyOn(window, "confirm").mockReturnValue(true);
+
+      // Remove a widget so state differs from defaults
+      useDashboardStore.setState({
+        widgetConfigs: WIDGET_CONFIGS.filter((c) => c.type !== "FeedsTypesChart"),
+        isDirty: true,
+      });
+
+      renderEditor();
+      fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+      expect(useDashboardStore.getState().widgetConfigs).toEqual(WIDGET_CONFIGS);
+      expect(useDashboardStore.getState().isDirty).toBe(false);
+
+      vi.restoreAllMocks();
+    });
+
+    test("clicking Reset and cancelling does NOT restore defaults", () => {
+      vi.spyOn(window, "confirm").mockReturnValue(false);
+
+      const trimmedConfigs = WIDGET_CONFIGS.filter(
+        (c) => c.type !== "FeedsTypesChart",
+      );
+      useDashboardStore.setState({ widgetConfigs: trimmedConfigs, isDirty: true });
+
+      renderEditor();
+      fireEvent.click(screen.getByRole("button", { name: /reset/i }));
+
+      expect(useDashboardStore.getState().widgetConfigs).toEqual(trimmedConfigs);
+
+      vi.restoreAllMocks();
+    });
+  });
+
+  //  Add Widget dropdown 
+
+  describe("Add Widget dropdown", () => {
+    test("Add Widget button is disabled when all widgets are already on the grid", () => {
+      // Default config already has all widgets = dropdown should be disabled
+      renderEditor();
+      expect(screen.getByRole("button", { name: /add widget/i })).toBeDisabled();
+    });
+
+    test("Add Widget button is enabled when a widget has been removed", () => {
+      renderEditor();
+      const grid = screen.getByTestId("rgl-grid");
+      const [firstRemoveBtn] = within(grid).getAllByTitle("Remove widget");
+      fireEvent.click(firstRemoveBtn);
+
+      expect(screen.getByRole("button", { name: /add widget/i })).not.toBeDisabled();
+    });
+
+    test("noGrid widget type (EnrichmentLookup) does NOT appear in the Add Widget dropdown", () => {
+      // Remove a grid widget so the dropdown opens with at least one item
+      useDashboardStore.setState({
+        widgetConfigs: WIDGET_CONFIGS.filter((c) => c.type !== "FeedsTypesChart"),
+        layouts: {
+          lg: DASHBOARD_LAYOUTS.lg.filter((i) => i.i !== "FeedsTypesChart"),
+          md: DASHBOARD_LAYOUTS.md.filter((i) => i.i !== "FeedsTypesChart"),
+          sm: DASHBOARD_LAYOUTS.sm.filter((i) => i.i !== "FeedsTypesChart"),
+        },
+        isDirty: true,
+      });
+
+      renderEditor();
+      fireEvent.click(screen.getByRole("button", { name: /add widget/i }));
+
+      // FeedsTypesChart should appear as an option
+      expect(screen.getByText("Feeds: Types")).toBeInTheDocument();
+      // EnrichmentLookup (noGrid) must NOT appear in the dropdown
+      const dropdownMenu = screen.getByRole("menu");
+      expect(within(dropdownMenu).queryByText("Enrichment Lookup")).not.toBeInTheDocument();
+    });
+  });
+
+  // empty state
+  describe("empty state", () => {
+    test("shows empty-state message when all grid widgets are removed", () => {
+      useDashboardStore.setState({
+        widgetConfigs: WIDGET_CONFIGS.filter((c) => c.noGrid),
+        layouts: { lg: [], md: [], sm: [] },
+        isDirty: true,
+      });
+
+      renderEditor();
+
+      expect(
+        screen.getByText(/no widgets/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByTestId("rgl-grid")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/components/dashboard/ConfigEditor.test.jsx
+++ b/frontend/tests/components/dashboard/ConfigEditor.test.jsx
@@ -14,9 +14,15 @@ vi.mock("../../../src/components/dashboard/utils/charts", () => ({
   FeedsTypesChart: () => <div data-testid="widget-FeedsTypesChart" />,
   FeedsSourcesChart: () => <div data-testid="widget-FeedsSourcesChart" />,
   FeedsDownloadsChart: () => <div data-testid="widget-FeedsDownloadsChart" />,
-  EnrichmentSourcesChart: () => <div data-testid="widget-EnrichmentSourcesChart" />,
-  EnrichmentRequestsChart: () => <div data-testid="widget-EnrichmentRequestsChart" />,
-  AttackOriginCountriesChart: () => <div data-testid="widget-AttackOriginCountriesChart" />,
+  EnrichmentSourcesChart: () => (
+    <div data-testid="widget-EnrichmentSourcesChart" />
+  ),
+  EnrichmentRequestsChart: () => (
+    <div data-testid="widget-EnrichmentRequestsChart" />
+  ),
+  AttackOriginCountriesChart: () => (
+    <div data-testid="widget-AttackOriginCountriesChart" />
+  ),
 }));
 
 vi.mock("../../../src/components/dashboard/AttackOriginMap", () => ({
@@ -93,13 +99,17 @@ describe("ConfigEditor", () => {
 
     test("renders a back-to-dashboard link", () => {
       renderEditor();
-      expect(screen.getByRole("link", { name: /dashboard/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("link", { name: /dashboard/i }),
+      ).toBeInTheDocument();
     });
 
     test("renders Save and Reset buttons", () => {
       renderEditor();
       expect(screen.getByRole("button", { name: /save/i })).toBeInTheDocument();
-      expect(screen.getByRole("button", { name: /reset/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /reset/i }),
+      ).toBeInTheDocument();
     });
 
     test("renders the Add Widget button", () => {
@@ -131,10 +141,18 @@ describe("ConfigEditor", () => {
       expect(within(grid).getByText("Feeds: Types")).toBeInTheDocument();
       expect(within(grid).getByText("Feeds: Sources")).toBeInTheDocument();
       expect(within(grid).getByText("Feeds: Downloads")).toBeInTheDocument();
-      expect(within(grid).getByText("Enrichment Service: Sources")).toBeInTheDocument();
-      expect(within(grid).getByText("Enrichment Service: Requests")).toBeInTheDocument();
-      expect(within(grid).getByText("Attack Origins: World Map")).toBeInTheDocument();
-      expect(within(grid).getByText("Attack Origins: Top Countries")).toBeInTheDocument();
+      expect(
+        within(grid).getByText("Enrichment Service: Sources"),
+      ).toBeInTheDocument();
+      expect(
+        within(grid).getByText("Enrichment Service: Requests"),
+      ).toBeInTheDocument();
+      expect(
+        within(grid).getByText("Attack Origins: World Map"),
+      ).toBeInTheDocument();
+      expect(
+        within(grid).getByText("Attack Origins: Top Countries"),
+      ).toBeInTheDocument();
     });
 
     test("renders a remove (✕) button for each grid widget", () => {
@@ -155,7 +173,9 @@ describe("ConfigEditor", () => {
       // The noGrid widget's card header should exist on the page...
       expect(screen.getByText("Enrichment Lookup")).toBeInTheDocument();
       // ...but NOT inside the RGL grid
-      expect(within(grid).queryByText("Enrichment Lookup")).not.toBeInTheDocument();
+      expect(
+        within(grid).queryByText("Enrichment Lookup"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -236,14 +256,18 @@ describe("ConfigEditor", () => {
 
       // Remove a widget so state differs from defaults
       useDashboardStore.setState({
-        widgetConfigs: WIDGET_CONFIGS.filter((c) => c.type !== "FeedsTypesChart"),
+        widgetConfigs: WIDGET_CONFIGS.filter(
+          (c) => c.type !== "FeedsTypesChart",
+        ),
         isDirty: true,
       });
 
       renderEditor();
       fireEvent.click(screen.getByRole("button", { name: /reset/i }));
 
-      expect(useDashboardStore.getState().widgetConfigs).toEqual(WIDGET_CONFIGS);
+      expect(useDashboardStore.getState().widgetConfigs).toEqual(
+        WIDGET_CONFIGS,
+      );
       expect(useDashboardStore.getState().isDirty).toBe(false);
 
       vi.restoreAllMocks();
@@ -255,24 +279,31 @@ describe("ConfigEditor", () => {
       const trimmedConfigs = WIDGET_CONFIGS.filter(
         (c) => c.type !== "FeedsTypesChart",
       );
-      useDashboardStore.setState({ widgetConfigs: trimmedConfigs, isDirty: true });
+      useDashboardStore.setState({
+        widgetConfigs: trimmedConfigs,
+        isDirty: true,
+      });
 
       renderEditor();
       fireEvent.click(screen.getByRole("button", { name: /reset/i }));
 
-      expect(useDashboardStore.getState().widgetConfigs).toEqual(trimmedConfigs);
+      expect(useDashboardStore.getState().widgetConfigs).toEqual(
+        trimmedConfigs,
+      );
 
       vi.restoreAllMocks();
     });
   });
 
-  //  Add Widget dropdown 
+  //  Add Widget dropdown
 
   describe("Add Widget dropdown", () => {
     test("Add Widget button is disabled when all widgets are already on the grid", () => {
       // Default config already has all widgets = dropdown should be disabled
       renderEditor();
-      expect(screen.getByRole("button", { name: /add widget/i })).toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /add widget/i }),
+      ).toBeDisabled();
     });
 
     test("Add Widget button is enabled when a widget has been removed", () => {
@@ -281,13 +312,17 @@ describe("ConfigEditor", () => {
       const [firstRemoveBtn] = within(grid).getAllByTitle("Remove widget");
       fireEvent.click(firstRemoveBtn);
 
-      expect(screen.getByRole("button", { name: /add widget/i })).not.toBeDisabled();
+      expect(
+        screen.getByRole("button", { name: /add widget/i }),
+      ).not.toBeDisabled();
     });
 
     test("noGrid widget type (EnrichmentLookup) does NOT appear in the Add Widget dropdown", () => {
       // Remove a grid widget so the dropdown opens with at least one item
       useDashboardStore.setState({
-        widgetConfigs: WIDGET_CONFIGS.filter((c) => c.type !== "FeedsTypesChart"),
+        widgetConfigs: WIDGET_CONFIGS.filter(
+          (c) => c.type !== "FeedsTypesChart",
+        ),
         layouts: {
           lg: DASHBOARD_LAYOUTS.lg.filter((i) => i.i !== "FeedsTypesChart"),
           md: DASHBOARD_LAYOUTS.md.filter((i) => i.i !== "FeedsTypesChart"),
@@ -303,7 +338,9 @@ describe("ConfigEditor", () => {
       expect(screen.getByText("Feeds: Types")).toBeInTheDocument();
       // EnrichmentLookup (noGrid) must NOT appear in the dropdown
       const dropdownMenu = screen.getByRole("menu");
-      expect(within(dropdownMenu).queryByText("Enrichment Lookup")).not.toBeInTheDocument();
+      expect(
+        within(dropdownMenu).queryByText("Enrichment Lookup"),
+      ).not.toBeInTheDocument();
     });
   });
 
@@ -318,9 +355,7 @@ describe("ConfigEditor", () => {
 
       renderEditor();
 
-      expect(
-        screen.getByText(/no widgets/i),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/no widgets/i)).toBeInTheDocument();
       expect(screen.queryByTestId("rgl-grid")).not.toBeInTheDocument();
     });
   });

--- a/frontend/tests/stores/useDashboardStore.test.js
+++ b/frontend/tests/stores/useDashboardStore.test.js
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const localStorageStore = {};
+const localStorageMock = {
+  getItem: vi.fn((key) => localStorageStore[key] ?? null),
+  setItem: vi.fn((key, value) => {
+    localStorageStore[key] = value;
+  }),
+  removeItem: vi.fn((key) => {
+    delete localStorageStore[key];
+  }),
+  clear: vi.fn(() => {
+    Object.keys(localStorageStore).forEach((k) => delete localStorageStore[k]);
+  }),
+};
+Object.defineProperty(global, "localStorage", { value: localStorageMock });
+
+import useDashboardStore from "../../src/stores/useDashboardStore";
+import {
+  WIDGET_CONFIGS,
+  DASHBOARD_LAYOUTS,
+} from "../../src/components/dashboard/defaultDashboardConfig";
+
+// helpter to reset store to defaults
+function resetStore() {
+  useDashboardStore.setState({
+    layouts: DASHBOARD_LAYOUTS,
+    widgetConfigs: WIDGET_CONFIGS,
+    isDirty: false,
+    savedVersion: 0,
+  });
+}
+
+describe("useDashboardStore", () => {
+  beforeEach(() => {
+    resetStore();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    localStorageMock.clear();
+  });
+
+  // Initial state
+
+  describe("initial state", () => {
+    test("starts with default widget configs", () => {
+      const { widgetConfigs } = useDashboardStore.getState();
+      expect(widgetConfigs).toEqual(WIDGET_CONFIGS);
+    });
+
+    test("starts with default layouts", () => {
+      const { layouts } = useDashboardStore.getState();
+      expect(layouts).toEqual(DASHBOARD_LAYOUTS);
+    });
+
+    test("isDirty starts false", () => {
+      expect(useDashboardStore.getState().isDirty).toBe(false);
+    });
+
+    test("savedVersion starts at 0", () => {
+      expect(useDashboardStore.getState().savedVersion).toBe(0);
+    });
+  });
+
+  // setLayouts
+
+  describe("setLayouts", () => {
+    test("replaces layouts and marks store dirty", () => {
+      const newLayouts = { lg: [{ i: "X", x: 0, y: 0, w: 12, h: 9 }], md: [], sm: [] };
+      useDashboardStore.getState().setLayouts(newLayouts);
+
+      const state = useDashboardStore.getState();
+      expect(state.layouts).toEqual(newLayouts);
+      expect(state.isDirty).toBe(true);
+    });
+
+    test("does not change savedVersion", () => {
+      useDashboardStore.getState().setLayouts({ lg: [], md: [], sm: [] });
+      expect(useDashboardStore.getState().savedVersion).toBe(0);
+    });
+  });
+
+  // setWidgetConfigs
+
+  describe("setWidgetConfigs", () => {
+    test("replaces widgetConfigs and marks store dirty", () => {
+      const newConfigs = [{ type: "FeedsTypesChart", id: "FeedsTypesChart" }];
+      useDashboardStore.getState().setWidgetConfigs(newConfigs);
+
+      const state = useDashboardStore.getState();
+      expect(state.widgetConfigs).toEqual(newConfigs);
+      expect(state.isDirty).toBe(true);
+    });
+  });
+
+  // save
+
+  describe("save", () => {
+    test("clears isDirty", () => {
+      useDashboardStore.setState({ isDirty: true });
+      useDashboardStore.getState().save();
+      expect(useDashboardStore.getState().isDirty).toBe(false);
+    });
+
+    test("increments savedVersion by 1 each call", () => {
+      useDashboardStore.getState().save();
+      expect(useDashboardStore.getState().savedVersion).toBe(1);
+      useDashboardStore.getState().save();
+      expect(useDashboardStore.getState().savedVersion).toBe(2);
+    });
+
+    test("preserves current layouts and widgetConfigs", () => {
+      const customLayouts = { lg: [{ i: "A", x: 0, y: 0, w: 6, h: 9 }], md: [], sm: [] };
+      useDashboardStore.setState({ layouts: customLayouts, isDirty: true });
+      useDashboardStore.getState().save();
+      expect(useDashboardStore.getState().layouts).toEqual(customLayouts);
+    });
+  });
+
+  // resetToDefault
+
+  describe("resetToDefault", () => {
+    test("restores default widgetConfigs", () => {
+      useDashboardStore.setState({ widgetConfigs: [] });
+      useDashboardStore.getState().resetToDefault();
+      expect(useDashboardStore.getState().widgetConfigs).toEqual(WIDGET_CONFIGS);
+    });
+
+    test("restores default layouts", () => {
+      useDashboardStore.setState({ layouts: { lg: [], md: [], sm: [] } });
+      useDashboardStore.getState().resetToDefault();
+      expect(useDashboardStore.getState().layouts).toEqual(DASHBOARD_LAYOUTS);
+    });
+
+    test("clears isDirty", () => {
+      useDashboardStore.setState({ isDirty: true });
+      useDashboardStore.getState().resetToDefault();
+      expect(useDashboardStore.getState().isDirty).toBe(false);
+    });
+
+    test("increments savedVersion so Dashboard remounts DashboardRenderer", () => {
+      const before = useDashboardStore.getState().savedVersion;
+      useDashboardStore.getState().resetToDefault();
+      expect(useDashboardStore.getState().savedVersion).toBe(before + 1);
+    });
+  });
+
+  // savedVersion as React key
+
+  describe("savedVersion remount signal", () => {
+    test("save() always increments even when isDirty was already false", () => {
+      // edge case, calling save twice without any dirty change
+      useDashboardStore.getState().save();
+      useDashboardStore.getState().save();
+      expect(useDashboardStore.getState().savedVersion).toBe(2);
+    });
+
+    test("setLayouts does NOT increment savedVersion", () => {
+      useDashboardStore.getState().setLayouts({ lg: [], md: [], sm: [] });
+      expect(useDashboardStore.getState().savedVersion).toBe(0);
+    });
+  });
+
+  // dirty / clean cycle
+
+  describe("dirty / clean cycle", () => {
+    test("setLayouts -> isDirty=true, save -> isDirty=false", () => {
+      const store = useDashboardStore.getState();
+      store.setLayouts({ lg: [], md: [], sm: [] });
+      expect(useDashboardStore.getState().isDirty).toBe(true);
+      useDashboardStore.getState().save();
+      expect(useDashboardStore.getState().isDirty).toBe(false);
+    });
+
+    test("setWidgetConfigs -> isDirty=true, resetToDefault -> isDirty=false", () => {
+      useDashboardStore.getState().setWidgetConfigs([]);
+      expect(useDashboardStore.getState().isDirty).toBe(true);
+      useDashboardStore.getState().resetToDefault();
+      expect(useDashboardStore.getState().isDirty).toBe(false);
+    });
+  });
+});

--- a/frontend/tests/stores/useDashboardStore.test.js
+++ b/frontend/tests/stores/useDashboardStore.test.js
@@ -67,7 +67,11 @@ describe("useDashboardStore", () => {
 
   describe("setLayouts", () => {
     test("replaces layouts and marks store dirty", () => {
-      const newLayouts = { lg: [{ i: "X", x: 0, y: 0, w: 12, h: 9 }], md: [], sm: [] };
+      const newLayouts = {
+        lg: [{ i: "X", x: 0, y: 0, w: 12, h: 9 }],
+        md: [],
+        sm: [],
+      };
       useDashboardStore.getState().setLayouts(newLayouts);
 
       const state = useDashboardStore.getState();
@@ -111,7 +115,11 @@ describe("useDashboardStore", () => {
     });
 
     test("preserves current layouts and widgetConfigs", () => {
-      const customLayouts = { lg: [{ i: "A", x: 0, y: 0, w: 6, h: 9 }], md: [], sm: [] };
+      const customLayouts = {
+        lg: [{ i: "A", x: 0, y: 0, w: 6, h: 9 }],
+        md: [],
+        sm: [],
+      };
       useDashboardStore.setState({ layouts: customLayouts, isDirty: true });
       useDashboardStore.getState().save();
       expect(useDashboardStore.getState().layouts).toEqual(customLayouts);
@@ -124,7 +132,9 @@ describe("useDashboardStore", () => {
     test("restores default widgetConfigs", () => {
       useDashboardStore.setState({ widgetConfigs: [] });
       useDashboardStore.getState().resetToDefault();
-      expect(useDashboardStore.getState().widgetConfigs).toEqual(WIDGET_CONFIGS);
+      expect(useDashboardStore.getState().widgetConfigs).toEqual(
+        WIDGET_CONFIGS,
+      );
     });
 
     test("restores default layouts", () => {

--- a/frontend/tests/wrappers/SuperuserGuard.test.jsx
+++ b/frontend/tests/wrappers/SuperuserGuard.test.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import SuperuserGuard from "../../src/wrappers/SuperuserGuard";
+
+// Mock useAuthStore
+const mockUseAuthStore = vi.fn();
+vi.mock("../../src/stores", () => ({
+  useAuthStore: (selector) => mockUseAuthStore(selector),
+}));
+
+describe("SuperuserGuard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("renders children when user is a superuser", () => {
+    mockUseAuthStore.mockImplementation((selector) =>
+      selector({ isSuperuser: true }),
+    );
+
+    render(
+      <SuperuserGuard>
+        <div>Admin Content</div>
+      </SuperuserGuard>,
+    );
+
+    expect(screen.getByText("Admin Content")).toBeInTheDocument();
+    expect(screen.queryByText("Access Restricted")).not.toBeInTheDocument();
+  });
+
+  test("shows access-restricted message when user is NOT a superuser", () => {
+    mockUseAuthStore.mockImplementation((selector) =>
+      selector({ isSuperuser: false }),
+    );
+
+    render(
+      <SuperuserGuard>
+        <div>Admin Content</div>
+      </SuperuserGuard>,
+    );
+
+    expect(screen.queryByText("Admin Content")).not.toBeInTheDocument();
+    expect(screen.getByText("Access Restricted")).toBeInTheDocument();
+    expect(
+      screen.getByText("This page is only available to superusers."),
+    ).toBeInTheDocument();
+  });
+
+  test("shows the lock emoji in the restricted view", () => {
+    mockUseAuthStore.mockImplementation((selector) =>
+      selector({ isSuperuser: false }),
+    );
+
+    render(
+      <SuperuserGuard>
+        <div>Admin Content</div>
+      </SuperuserGuard>,
+    );
+
+    expect(screen.getByText("🔒")).toBeInTheDocument();
+  });
+
+  test("renders multiple children correctly for superusers", () => {
+    mockUseAuthStore.mockImplementation((selector) =>
+      selector({ isSuperuser: true }),
+    );
+
+    render(
+      <SuperuserGuard>
+        <div>Child A</div>
+        <div>Child B</div>
+      </SuperuserGuard>,
+    );
+
+    expect(screen.getByText("Child A")).toBeInTheDocument();
+    expect(screen.getByText("Child B")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
# Description

Implement the admin-only dashboard configuration UI described in the GSoC project plan (Deliverable 4).
Superusers will be able to customise the dashboard layout interactively.

NOTE: Currently layout is not persisted.

### Related issues
#1425

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [x] I have provided a screenshot of the result in the PR.
- [x] I have created new frontend tests for the new component or updated existing ones.

### Video

https://github.com/user-attachments/assets/b53705ff-9940-4f24-837f-fd7485c052c2

