### PR TITLE
OpenAPI docs for more endpoints. Progresses #962

### DIFF
--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,5 +1,6 @@
 from .common import *
 from .events import *
 from .feeds import *
+from .health import *
 from .payloads import *
 from .utils import *

--- a/api/serializers/__init__.py
+++ b/api/serializers/__init__.py
@@ -1,4 +1,5 @@
 from .common import *
+from .cowrie_session import *
 from .events import *
 from .feeds import *
 from .health import *

--- a/api/serializers/common.py
+++ b/api/serializers/common.py
@@ -4,18 +4,17 @@ import re
 from rest_framework import serializers
 
 from greedybear.consts import REGEX_DOMAIN
-from greedybear.models import IOC, Honeypot, Sensor, Tag
+from greedybear.models import IOC, Sensor, Tag
 from greedybear.utils import is_ip_address
 
 logger = logging.getLogger(__name__)
 
 
-class HoneypotSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Honeypot
-
-    def to_representation(self, value):
-        return value.name
+class HoneypotSerializer(serializers.SlugRelatedField):
+    def __init__(self, **kwargs):
+        kwargs.setdefault("slug_field", "name")
+        kwargs.setdefault("read_only", True)
+        super().__init__(**kwargs)
 
 
 class TagSerializer(serializers.ModelSerializer):
@@ -42,10 +41,8 @@ class IOCSerializer(serializers.ModelSerializer):
         ]
 
 
-class EnrichmentSerializer(serializers.Serializer):
-    found = serializers.BooleanField(read_only=True, default=False)
-    ioc = IOCSerializer(read_only=True, default=None)
-    query = serializers.CharField(max_length=250)
+class EnrichmentRequestSerializer(serializers.Serializer):
+    query = serializers.CharField(max_length=250, help_text="The IP address or domain to lookup.")
 
     def validate(self, data):
         """
@@ -59,11 +56,10 @@ class EnrichmentSerializer(serializers.Serializer):
 
         if not is_ip_address(observable) and not is_domain:
             raise serializers.ValidationError("Observable is not a valid IP address or domain")
-
-        try:
-            required_object = IOC.objects.prefetch_related("tags", "sensors").get(name=observable)
-            data["found"] = True
-            data["ioc"] = required_object
-        except IOC.DoesNotExist:
-            data["found"] = False
         return data
+
+
+class EnrichmentSerializer(serializers.Serializer):
+    found = serializers.BooleanField(read_only=True, default=False)
+    ioc = IOCSerializer(read_only=True, default=None, allow_null=True)
+    query = serializers.CharField(max_length=250)

--- a/api/serializers/cowrie_session.py
+++ b/api/serializers/cowrie_session.py
@@ -1,0 +1,52 @@
+from rest_framework import serializers
+
+
+class CowrieSessionRequestSerializer(serializers.Serializer):
+    query = serializers.CharField(
+        max_length=256,
+        help_text=(
+            "The search term, can be an IP address, the SHA-256 hash of a command sequence, or a password. "
+            'SHA-256 hashes should match command sequences generated using Python\'s `"\n".join(sequence)` format.'
+        ),
+    )
+    include_similar = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text=(
+            "When `true`, expands the result to include all sessions that executed command sequences "
+            "belonging to the same cluster(s) as command sequences found in the initial query result. "
+            "Requires CLUSTER_COWRIE_COMMAND_SEQUENCES enabled in configuration."
+        ),
+    )
+    include_credentials = serializers.BooleanField(
+        required=False, default=False, help_text="When `true`, includes all credentials used across matching Cowrie sessions."
+    )
+    include_session_data = serializers.BooleanField(
+        required=False, default=False, help_text="When `true`, includes detailed information about matching Cowrie sessions."
+    )
+
+
+class SessionDetailSerializer(serializers.Serializer):
+    """A single matching Cowrie session."""
+
+    time = serializers.DateTimeField(help_text="Session start time.")
+    duration = serializers.FloatField(help_text="Session duration in seconds.")
+    source = serializers.IPAddressField(help_text="Source IP address.")
+    interactions = serializers.IntegerField()
+    credentials = serializers.ListField(child=serializers.CharField(), help_text="Credentials used in this session, as `username | password`.")
+    commands = serializers.CharField(help_text="Command sequence executed, newline-delimited. Empty when the session ran no commands.")
+
+
+class CowrieSessionSerializer(serializers.Serializer):
+    """Aggregated view of the sessions matching a query."""
+
+    query = serializers.CharField(max_length=256, help_text="The query this result was produced for.")
+    license = serializers.CharField(required=False, help_text="Present when a feed license is configured.")
+    commands = serializers.ListField(child=serializers.CharField(), help_text="Unique command sequences, each newline-delimited.")
+    sources = serializers.ListField(child=serializers.IPAddressField(), help_text="Unique source IP addresses.")
+    credentials = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="Unique credentials across all matching sessions. Present when `include_credentials` is true.",
+    )
+    sessions = SessionDetailSerializer(many=True, required=False, help_text="Present when `include_session_data` is true.")

--- a/api/serializers/health.py
+++ b/api/serializers/health.py
@@ -1,0 +1,54 @@
+from rest_framework import serializers
+
+DATABASE_STATES = ["up", "down", "degraded"]
+QCLUSTER_STATES = ["up", "idle", "down", "unknown"]
+ELASTICSEARCH_STATES = ["up", "down", "not configured", "unknown"]
+
+
+class SystemStatusSerializer(serializers.Serializer):
+    uptime_seconds = serializers.IntegerField(read_only=True, help_text="Seconds elapsed since the application started.")
+    database = serializers.ChoiceField(choices=DATABASE_STATES, read_only=True, help_text="`degraded` means the database answers but the aggregation failed.")
+    qcluster = serializers.ChoiceField(
+        choices=QCLUSTER_STATES, read_only=True, help_text="`idle` means jobs are scheduled but none ran in the last 10 minutes."
+    )
+    elasticsearch = serializers.ChoiceField(choices=ELASTICSEARCH_STATES, read_only=True, help_text="`not configured` means no Elasticsearch client is set up.")
+
+
+class IocCountsSerializer(serializers.Serializer):
+    total = serializers.IntegerField(help_text="All IOCs on record.")
+    new_last_24h = serializers.IntegerField(help_text="IOCs first seen in the last 24 hours.")
+
+
+class SessionCountsSerializer(serializers.Serializer):
+    total = serializers.IntegerField(help_text="All Cowrie sessions on record.")
+    last_24h = serializers.IntegerField(help_text="Cowrie sessions started in the last 24 hours.")
+
+
+class HoneypotCountsSerializer(serializers.Serializer):
+    total = serializers.IntegerField(help_text="Configured honeypots.")
+    active = serializers.IntegerField(help_text="Honeypots currently marked active.")
+
+
+class ThreatListCountsSerializer(serializers.Serializer):
+    firehol = serializers.IntegerField(help_text="Entries pulled from the FireHol lists.")
+    mass_scanners = serializers.IntegerField(help_text="Known mass scanners on record.")
+    tor_exit_nodes = serializers.IntegerField(help_text="Known Tor exit nodes on record.")
+
+
+class JobCountsSerializer(serializers.Serializer):
+    scheduled = serializers.IntegerField(help_text="Django-Q schedules currently registered.")
+    failed_last_24h = serializers.IntegerField(help_text="Jobs that failed in the last 24 hours.")
+    successful_last_24h = serializers.IntegerField(help_text="Jobs that succeeded in the last 24 hours.")
+
+
+class OverviewSerializer(serializers.Serializer):
+    iocs = IocCountsSerializer(required=False)
+    sessions = SessionCountsSerializer(required=False)
+    honeypots = HoneypotCountsSerializer(required=False)
+    threat_lists = ThreatListCountsSerializer(required=False)
+    jobs = JobCountsSerializer(required=False)
+
+
+class HealthSerializer(serializers.Serializer):
+    system = SystemStatusSerializer(read_only=True)
+    overview = OverviewSerializer(read_only=True, help_text="Empty when the database is down.")

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,6 +8,7 @@ from api.views import (
     AdvancedFeedView,
     AsnFeedView,
     ConsumeFeedView,
+    CowrieSessionView,
     EnrichmentView,
     HealthView,
     HoneypotPayloadViewSet,
@@ -17,7 +18,6 @@ from api.views import (
     StatisticsViewSet,
     TrendingFeedView,
     command_sequence_view,
-    cowrie_session_view,
     event_status_view,
     events_create_view,
     general_honeypot_list,
@@ -49,6 +49,7 @@ documented_urlpatterns = [
     path("feeds/revoke/<str:token>", ShareTokenViewSet.as_view({"get": "revoke"})),
     path("feeds/tokens/", ShareTokenViewSet.as_view({"get": "list_tokens"})),
     path("enrichment", EnrichmentView.as_view()),
+    path("cowrie_session", CowrieSessionView.as_view()),
     path("health/", HealthView.as_view()),
 ]
 schema_urlconf = [path("api/", include(documented_urlpatterns + documented_router.urls))]
@@ -60,7 +61,6 @@ urlpatterns = [
     path("schema/", SpectacularAPIView.as_view(urlconf=schema_urlconf), name="schema"),
     path("schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
-    path("cowrie_session", cowrie_session_view),
     path("command_sequence", command_sequence_view),
     path("general_honeypot", general_honeypot_list),
     path("news/", news_view),

--- a/api/urls.py
+++ b/api/urls.py
@@ -8,6 +8,8 @@ from api.views import (
     AdvancedFeedView,
     AsnFeedView,
     ConsumeFeedView,
+    EnrichmentView,
+    HealthView,
     HoneypotPayloadViewSet,
     PaginatedFeedView,
     ShareTokenViewSet,
@@ -16,11 +18,9 @@ from api.views import (
     TrendingFeedView,
     command_sequence_view,
     cowrie_session_view,
-    enrichment_view,
     event_status_view,
     events_create_view,
     general_honeypot_list,
-    health_view,
     news_view,
     sensor_create_view,
 )
@@ -48,6 +48,8 @@ documented_urlpatterns = [
     path("feeds/consume/<str:token>", ConsumeFeedView.as_view()),
     path("feeds/revoke/<str:token>", ShareTokenViewSet.as_view({"get": "revoke"})),
     path("feeds/tokens/", ShareTokenViewSet.as_view({"get": "list_tokens"})),
+    path("enrichment", EnrichmentView.as_view()),
+    path("health/", HealthView.as_view()),
 ]
 schema_urlconf = [path("api/", include(documented_urlpatterns + documented_router.urls))]
 
@@ -58,12 +60,10 @@ urlpatterns = [
     path("schema/", SpectacularAPIView.as_view(urlconf=schema_urlconf), name="schema"),
     path("schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
-    path("enrichment", enrichment_view),
     path("cowrie_session", cowrie_session_view),
     path("command_sequence", command_sequence_view),
     path("general_honeypot", general_honeypot_list),
     path("news/", news_view),
-    path("health/", health_view),
     path("sensor/", sensor_create_view),
     path("events/add/", events_create_view),
     path("events/status/<str:task_id>/", event_status_view),

--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -1,11 +1,10 @@
 # This file is a part of GreedyBear https://github.com/honeynet/GreedyBear
 # See the file 'LICENSE' for copying permission.
 import ipaddress
-import logging
 
 from certego_saas.apps.auth.backend import CookieTokenAuthentication
 from django.conf import settings
-from django.http import Http404, HttpResponseBadRequest
+from django.http import Http404
 from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
@@ -18,8 +17,6 @@ from api.serializers import CowrieSessionRequestSerializer, CowrieSessionSeriali
 from api.views.utils import save_request_source
 from greedybear.models import CommandSequence, CowrieSession, ViewType
 from greedybear.utils import is_ip_address, is_sha256hash
-
-logger = logging.getLogger(__name__)
 
 
 @extend_schema_view(
@@ -48,7 +45,8 @@ class CowrieSessionView(RequestLoggingMixin, APIView):
     def get(self, request: Request, *args, **kwargs):
         request_serializer = CowrieSessionRequestSerializer(data=request.query_params.dict())
         request_serializer.is_valid(raise_exception=True)
-        save_request_source(request, view=ViewType.ENRICHMENT_VIEW.value)
+        save_request_source(request, ViewType.COWRIE_SESSION_VIEW.value)
+
         observable = request_serializer.validated_data["query"]
         if is_ip_address(observable):
             sessions = CowrieSession.objects.filter(source__name=observable, duration__gt=0).prefetch_related("source", "commands", "credentials")
@@ -62,8 +60,6 @@ class CowrieSessionView(RequestLoggingMixin, APIView):
                 raise Http404(f"No command sequences found with hash: {observable}") from exc
             sessions = CowrieSession.objects.filter(commands=commands, duration__gt=0).prefetch_related("source", "commands", "credentials")
         else:
-            if len(observable) > 256:  # max_length of Credential.password field
-                return HttpResponseBadRequest("Query exceeds maximum password length")
             sessions = CowrieSession.objects.filter(credentials__password=observable, duration__gt=0).prefetch_related("source", "commands", "credentials")
             if not sessions.exists():
                 raise Http404(f"No information found for password: {observable}")

--- a/api/views/cowrie_session.py
+++ b/api/views/cowrie_session.py
@@ -6,130 +6,99 @@ import logging
 from certego_saas.apps.auth.backend import CookieTokenAuthentication
 from django.conf import settings
 from django.http import Http404, HttpResponseBadRequest
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import status
-from rest_framework.decorators import (
-    api_view,
-    authentication_classes,
-    permission_classes,
-)
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from api.views.utils import UnableToExtractSourceIPError, get_request_source_ip
-from greedybear.consts import GET
-from greedybear.models import CommandSequence, CowrieSession, Statistics, ViewType
+from api.mixins import RequestLoggingMixin
+from api.serializers import CowrieSessionRequestSerializer, CowrieSessionSerializer
+from api.views.utils import save_request_source
+from greedybear.models import CommandSequence, CowrieSession, ViewType
 from greedybear.utils import is_ip_address, is_sha256hash
 
 logger = logging.getLogger(__name__)
 
 
-@api_view([GET])
-@authentication_classes([CookieTokenAuthentication])
-@permission_classes([IsAuthenticated])
-def cowrie_session_view(request):
-    """
-    Retrieve Cowrie honeypot session data including command sequences, credentials, and session details.
-    Queries can be performed using an IP address to find all sessions from that source,
-    a SHA-256 hash to find sessions containing a specific command sequence,
-    or a password to find all sessions where that password was used.
+@extend_schema_view(
+    get=extend_schema(
+        tags=["Cowrie Session"],
+        summary="Session data from the Cowrie honeypot",
+        description=(
+            "Retrieve Cowrie honeypot session data including command sequences, credentials, and session details. "
+            "Queries can be performed using an IP address to find all sessions from that source, "
+            "a SHA-256 hash to find sessions containing a specific command sequence, "
+            "or a password to find all sessions where that password was used."
+        ),
+        parameters=[CowrieSessionRequestSerializer],
+        responses={
+            200: CowrieSessionSerializer,
+            400: OpenApiResponse(description="Missing or invalid `query` parameter."),
+            401: OpenApiResponse(description="Authentication credentials were not provided or are invalid."),
+            404: OpenApiResponse(description="No matching sessions found."),
+        },
+    )
+)
+class CowrieSessionView(RequestLoggingMixin, APIView):
+    authentication_classes = [CookieTokenAuthentication]
+    permission_classes = [IsAuthenticated]
 
-    Args:
-        request: The HTTP request object containing query parameters
-        query (str, required): The search term, can be an IP address, the SHA-256 hash of a command sequence,
-            or a password. SHA-256 hashes should match command sequences generated using Python's "\\n".join(sequence) format.
-        include_similar (bool, optional): When "true", expands the result to include all sessions that executed
-            command sequences belonging to the same cluster(s) as command sequences found in the initial query result.
-            Requires CLUSTER_COWRIE_COMMAND_SEQUENCES enabled in configuration. Default: false
-        include_credentials (bool, optional): When "true", includes all credentials used across matching Cowrie sessions.
-            Default: false
-        include_session_data (bool, optional): When "true", includes detailed information about matching Cowrie sessions.
-            Default: false
+    def get(self, request: Request, *args, **kwargs):
+        request_serializer = CowrieSessionRequestSerializer(data=request.query_params.dict())
+        request_serializer.is_valid(raise_exception=True)
+        save_request_source(request, view=ViewType.ENRICHMENT_VIEW.value)
+        observable = request_serializer.validated_data["query"]
+        if is_ip_address(observable):
+            sessions = CowrieSession.objects.filter(source__name=observable, duration__gt=0).prefetch_related("source", "commands", "credentials")
+            if not sessions.exists():
+                raise Http404(f"No information found for IP: {observable}")
 
-    Returns:
-        Response (200): JSON object containing:
-            - query (str): The original query parameter
-            - commands (list[str]): Unique command sequences (newline-delimited strings)
-            - sources (list[str]): Unique source IP addresses
-            - credentials (list[str], optional): Unique credentials if include_credentials=true
-            - sessions (list[dict], optional): Session details if include_session_data=true
-                - time (datetime): Session start time
-                - duration (float): Session duration in seconds
-                - source (str): Source IP address
-                - interactions (int): Number of interactions in session
-                - credentials (list[str]): Credentials used in this session
-                - commands (str): Command sequence executed (newline-delimited)
-        Response (400): Bad Request - Missing or invalid query parameter
-        Response (404): Not Found - No matching sessions found
-        Response (500): Internal Server Error - Unexpected error occurred
+        elif is_sha256hash(observable):
+            try:
+                commands = CommandSequence.objects.get(commands_hash=observable.lower())
+            except CommandSequence.DoesNotExist as exc:
+                raise Http404(f"No command sequences found with hash: {observable}") from exc
+            sessions = CowrieSession.objects.filter(commands=commands, duration__gt=0).prefetch_related("source", "commands", "credentials")
+        else:
+            if len(observable) > 256:  # max_length of Credential.password field
+                return HttpResponseBadRequest("Query exceeds maximum password length")
+            sessions = CowrieSession.objects.filter(credentials__password=observable, duration__gt=0).prefetch_related("source", "commands", "credentials")
+            if not sessions.exists():
+                raise Http404(f"No information found for password: {observable}")
 
-    Example Queries:
-        /api/cowrie_session?query=1.2.3.4
-        /api/cowrie_session?query=5120e94e366ec83a79ee80454e4d1c76c06499ab19032bcdc7f0b4523bdb37a6
-        /api/cowrie_session?query=1.2.3.4&include_credentials=true&include_session_data=true&include_similar=true
-        /api/cowrie_session?query=admin123
-    """
-    observable = request.query_params.get("query")
-    include_similar = request.query_params.get("include_similar", "false").lower() == "true"
-    include_credentials = request.query_params.get("include_credentials", "false").lower() == "true"
-    include_session_data = request.query_params.get("include_session_data", "false").lower() == "true"
+        if request_serializer.validated_data["include_similar"]:
+            commands = {s.commands for s in sessions if s.commands}
+            clusters = {cmd.cluster for cmd in commands if cmd.cluster is not None}
+            related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters, duration__gt=0).prefetch_related(
+                "source", "commands", "credentials"
+            )
+            sessions = sessions.union(related_sessions)
 
-    logger.info(f"Cowrie view requested by {request.user} for {observable}")
+        data = {
+            "query": observable,
+        }
+        if settings.FEEDS_LICENSE:
+            data["license"] = settings.FEEDS_LICENSE
 
-    if not observable:
-        return HttpResponseBadRequest("Missing required 'query' parameter")
+        unique_commands = {s.commands for s in sessions if s.commands}
+        data["commands"] = sorted("\n".join(cmd.commands) for cmd in unique_commands)
+        data["sources"] = sorted({s.source.name for s in sessions}, key=lambda ip: ipaddress.ip_address(ip))
+        if request_serializer.validated_data["include_credentials"]:
+            data["credentials"] = sorted({str(c) for s in sessions for c in s.credentials.all()})
+        if request_serializer.validated_data["include_session_data"]:
+            data["sessions"] = [
+                {
+                    "time": s.start_time,
+                    "duration": s.duration,
+                    "source": s.source.name,
+                    "interactions": s.interaction_count,
+                    "credentials": [str(c) for c in s.credentials.all()],
+                    "commands": "\n".join(s.commands.commands) if s.commands else "",
+                }
+                for s in sessions
+            ]
 
-    if is_ip_address(observable):
-        sessions = CowrieSession.objects.filter(source__name=observable, duration__gt=0).prefetch_related("source", "commands", "credentials")
-        if not sessions.exists():
-            raise Http404(f"No information found for IP: {observable}")
-
-    elif is_sha256hash(observable):
-        try:
-            commands = CommandSequence.objects.get(commands_hash=observable.lower())
-        except CommandSequence.DoesNotExist as exc:
-            raise Http404(f"No command sequences found with hash: {observable}") from exc
-        sessions = CowrieSession.objects.filter(commands=commands, duration__gt=0).prefetch_related("source", "commands", "credentials")
-    else:
-        if len(observable) > 256:  # max_length of Credential.password field
-            return HttpResponseBadRequest("Query exceeds maximum password length")
-        sessions = CowrieSession.objects.filter(credentials__password=observable, duration__gt=0).prefetch_related("source", "commands", "credentials")
-        if not sessions.exists():
-            raise Http404(f"No information found for password: {observable}")
-
-    try:
-        source_ip = get_request_source_ip(request)
-        Statistics(source=source_ip, view=ViewType.COWRIE_SESSION_VIEW.value).save()
-    except UnableToExtractSourceIPError:
-        logger.warning("Skipping statistics recording due to unable to extract source IP")
-
-    if include_similar:
-        commands = {s.commands for s in sessions if s.commands}
-        clusters = {cmd.cluster for cmd in commands if cmd.cluster is not None}
-        related_sessions = CowrieSession.objects.filter(commands__cluster__in=clusters, duration__gt=0).prefetch_related("source", "commands", "credentials")
-        sessions = sessions.union(related_sessions)
-
-    response_data = {
-        "query": observable,
-    }
-    if settings.FEEDS_LICENSE:
-        response_data["license"] = settings.FEEDS_LICENSE
-
-    unique_commands = {s.commands for s in sessions if s.commands}
-    response_data["commands"] = sorted("\n".join(cmd.commands) for cmd in unique_commands)
-    response_data["sources"] = sorted({s.source.name for s in sessions}, key=lambda ip: ipaddress.ip_address(ip))
-    if include_credentials:
-        response_data["credentials"] = sorted({str(c) for s in sessions for c in s.credentials.all()})
-    if include_session_data:
-        response_data["sessions"] = [
-            {
-                "time": s.start_time,
-                "duration": s.duration,
-                "source": s.source.name,
-                "interactions": s.interaction_count,
-                "credentials": [str(c) for c in s.credentials.all()],
-                "commands": "\n".join(s.commands.commands) if s.commands else "",
-            }
-            for s in sessions
-        ]
-
-    return Response(response_data, status=status.HTTP_200_OK)
+        response_serializer = CowrieSessionSerializer(data)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/api/views/enrichment.py
+++ b/api/views/enrichment.py
@@ -1,49 +1,56 @@
 # This file is a part of GreedyBear https://github.com/honeynet/GreedyBear
 # See the file 'LICENSE' for copying permission.
-import logging
 
 from certego_saas.apps.auth.backend import CookieTokenAuthentication
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
 from rest_framework import status
-from rest_framework.decorators import (
-    api_view,
-    authentication_classes,
-    permission_classes,
-)
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
-from api.serializers import EnrichmentSerializer
-from api.views.utils import UnableToExtractSourceIPError, get_request_source_ip
-from greedybear.consts import GET
-from greedybear.models import Statistics, ViewType
-
-logger = logging.getLogger(__name__)
+from api.mixins import RequestLoggingMixin
+from api.serializers import EnrichmentRequestSerializer, EnrichmentSerializer
+from api.views.utils import save_request_source
+from greedybear.models import IOC, ViewType
 
 
-@api_view([GET])
-@authentication_classes([CookieTokenAuthentication])
-@permission_classes([IsAuthenticated])
-def enrichment_view(request):
-    """
-    Handle enrichment requests for a specific observable (domain or IP address).
+@extend_schema_view(
+    get=extend_schema(
+        tags=["Enrichment"],
+        summary="Enrich a single observable",
+        description=(
+            "Look up an IP address or domain in the IOC database. "
+            "A well-formed observable always returns 200: `found` states whether GreedyBear knows it and `ioc` carries the full record when it does."
+        ),
+        parameters=[EnrichmentRequestSerializer],
+        responses={
+            200: EnrichmentSerializer,
+            400: OpenApiResponse(description="The `query` parameter is missing or is not a valid IP address or domain."),
+            401: OpenApiResponse(description="Authentication credentials were not provided or are invalid."),
+        },
+    )
+)
+class EnrichmentView(RequestLoggingMixin, APIView):
+    authentication_classes = [CookieTokenAuthentication]
+    permission_classes = [IsAuthenticated]
 
-    Args:
-        request: The incoming request object containing query parameters.
-
-    Returns:
-        Response: A JSON response indicating whether the observable was found,
-        and if so, the corresponding IOC.
-    """
-    observable_name = request.query_params.get("query")
-    logger.info(f"Enrichment view requested for: {observable_name}")
-    serializer = EnrichmentSerializer(data=request.query_params, context={"request": request})
-    serializer.is_valid(raise_exception=True)
-
-    try:
-        source_ip = get_request_source_ip(request)
-        request_source = Statistics(source=source_ip, view=ViewType.ENRICHMENT_VIEW.value)
-        request_source.save()
-    except UnableToExtractSourceIPError:
-        logger.warning("Skipping statistics recording due to unable to extract source IP")
-
-    return Response(serializer.data, status=status.HTTP_200_OK)
+    def get(self, request: Request, *args, **kwargs):
+        request_serializer = EnrichmentRequestSerializer(data=request.query_params.dict())
+        request_serializer.is_valid(raise_exception=True)
+        save_request_source(request, view=ViewType.ENRICHMENT_VIEW.value)
+        query = request_serializer.validated_data["query"]
+        try:
+            data = {
+                "found": True,
+                "ioc": IOC.objects.prefetch_related("tags", "sensors").get(name=query),
+                "query": query,
+            }
+        except IOC.DoesNotExist:
+            data = {
+                "found": False,
+                "ioc": None,
+                "query": query,
+            }
+        response_serializer = EnrichmentSerializer(data)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/api/views/enrichment.py
+++ b/api/views/enrichment.py
@@ -38,7 +38,8 @@ class EnrichmentView(RequestLoggingMixin, APIView):
     def get(self, request: Request, *args, **kwargs):
         request_serializer = EnrichmentRequestSerializer(data=request.query_params.dict())
         request_serializer.is_valid(raise_exception=True)
-        save_request_source(request, view=ViewType.ENRICHMENT_VIEW.value)
+        save_request_source(request, ViewType.ENRICHMENT_VIEW.value)
+
         query = request_serializer.validated_data["query"]
         try:
             data = {

--- a/api/views/feeds.py
+++ b/api/views/feeds.py
@@ -49,7 +49,7 @@ from api.views.utils import (
 from greedybear.consts import SHARE_TOKEN_SALT, TRENDING_FEEDS_DATA_VERSION_KEY
 from greedybear.cronjobs.repositories import TrendingBucketRepository
 from greedybear.cronjobs.trending import build_ranked_attackers
-from greedybear.models import IOC, ShareToken
+from greedybear.models import IOC, ShareToken, ViewType
 
 RENDERERS_BY_FORMAT = {
     "json": FeedJSONRenderer,
@@ -201,7 +201,7 @@ class BaseFeedView(RequestLoggingMixin, CachedResponseMixin, APIView):
         """Validate the request, build and sort the IOC queryset,
         render it in the requested format, and optionally paginate."""
         self.request_params = self.validate_request(request, **kwargs)
-        save_request_source(request)
+        save_request_source(request, ViewType.FEEDS_VIEW.value)
         cached_response = self.get_cached_response()
         if cached_response is not None:
             return cached_response

--- a/api/views/health.py
+++ b/api/views/health.py
@@ -2,14 +2,19 @@ import logging
 import time
 from datetime import datetime, timedelta
 
+from certego_saas.apps.auth.backend import CookieTokenAuthentication
 from django.conf import settings
 from django.db import connection
 from django.db.models import Count, Q
 from django_q.models import Schedule, Task
-from rest_framework.decorators import api_view, permission_classes
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_view
+from rest_framework import status
 from rest_framework.permissions import IsAdminUser
+from rest_framework.request import Request
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
+from api.serializers import HealthSerializer
 from greedybear.consts import START_TIME
 from greedybear.models import (
     IOC,
@@ -167,26 +172,22 @@ def get_status_overview():
     }
 
 
-@api_view(["GET"])
-@permission_classes([IsAdminUser])
-def health_view(request):
-    """
-    Health & overview endpoint.
+@extend_schema_view(
+    get=extend_schema(
+        tags=["Health"],
+        summary="Health & overview endpoint",
+        description=("Returns the current system status and aggregated observables. Accessible only to admin users."),
+        responses={
+            200: HealthSerializer,
+            401: OpenApiResponse(description="Authentication credentials were not provided or are invalid."),
+        },
+    )
+)
+class HealthView(APIView):
+    authentication_classes = [CookieTokenAuthentication]
+    permission_classes = [IsAdminUser]
 
-    Returns the current system status and aggregated observables.Accessible only to admin users.\
-
-    System status includes:
-     - database: "up", "down", or "degraded"
-     - qcluster: "up", "idle", or "down"
-     - elasticsearch: "up", "down", or "not configured"
-     - uptime_seconds: total system uptime in seconds
-
-    Overview data includes:
-     - iocs: total and new IOCs in the last 24 hours
-     - sessions: total Cowrie sessions and sessions in the last 24h
-     - honeypots: total and active honeypots
-     - threat_lists: counts of firehol, mass_scanners, tor_exit_nodes
-     - jobs: Django-Q jobs (scheduled, failed last 24h, successful last 24h)
-    """
-    data = get_status_overview()
-    return Response(data)
+    def get(self, request: Request, *args, **kwargs):
+        data = get_status_overview()
+        response_serializer = HealthSerializer(data)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/api/views/health.py
+++ b/api/views/health.py
@@ -180,6 +180,7 @@ def get_status_overview():
         responses={
             200: HealthSerializer,
             401: OpenApiResponse(description="Authentication credentials were not provided or are invalid."),
+            403: OpenApiResponse(description="Permission denied — requires admin privileges."),
         },
     )
 )

--- a/api/views/utils.py
+++ b/api/views/utils.py
@@ -11,6 +11,7 @@ from django.core.cache import cache
 from django.db import transaction
 from django.db.models import Count, F, Max, Min, Sum
 from rest_framework import status
+from rest_framework.request import Request
 from rest_framework.response import Response
 from stix2 import Bundle, ExternalReference, Indicator
 
@@ -45,10 +46,10 @@ def get_request_source_ip(request) -> str:
     raise UnableToExtractSourceIPError("No valid source IP found in request metadata")
 
 
-def save_request_source(request):
+def save_request_source(request: Request, view: str):
     try:
         source_ip = get_request_source_ip(request)
-        request_source = Statistics(source=source_ip)
+        request_source = Statistics(source=source_ip, view=view)
         request_source.save()
     except UnableToExtractSourceIPError:
         logger.warning("Skipping statistics recording due to unable to extract source IP")

--- a/greedybear/settings.py
+++ b/greedybear/settings.py
@@ -172,6 +172,8 @@ SPECTACULAR_SETTINGS = {
         {"name": "Feeds", "description": "Public and authenticated threat intelligence feeds."},
         {"name": "Feed Sharing", "description": "Create, consume, list and revoke shareable feed links."},
         {"name": "Payloads", "description": "Metadata and RBAC-gated download of honeypot-captured payloads."},
+        {"name": "Enrichment", "description": "Lookup for a single IP address or domain."},
+        {"name": "Health", "description": "Health and overview endpoint."},
     ],
     "SCHEMA_PATH_PREFIX": "/api",
 }

--- a/greedybear/settings.py
+++ b/greedybear/settings.py
@@ -173,6 +173,7 @@ SPECTACULAR_SETTINGS = {
         {"name": "Feed Sharing", "description": "Create, consume, list and revoke shareable feed links."},
         {"name": "Payloads", "description": "Metadata and RBAC-gated download of honeypot-captured payloads."},
         {"name": "Enrichment", "description": "Lookup for a single IP address or domain."},
+        {"name": "Cowrie Session", "description": "Session data from the Cowrie honeypot."},
         {"name": "Health", "description": "Health and overview endpoint."},
     ],
     "SCHEMA_PATH_PREFIX": "/api",

--- a/tests/api/views/test_cowrie_session_view.py
+++ b/tests/api/views/test_cowrie_session_view.py
@@ -150,9 +150,9 @@ class CowrieSessionViewTestCase(CustomTestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_include_credentials_invalid_value(self):
-        """Test that invalid boolean values default to false."""
+        """Test that invalid boolean values raise validation error."""
         response = self.client.get("/api/cowrie_session?query=140.246.171.141&include_credentials=maybe")
-        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.status_code, 400)
         self.assertNotIn("credentials", response.data)
 
     def test_case_insensitive_boolean_parameters(self):


### PR DESCRIPTION
# Description

This introduces and wires in serializers and OpenAPI documentation for three existing endpoints:
- Cowrie Session
- Enrichment
- Health

Functionally, nothing changes (except for some edge cases, see below). Only the automatic OpenAPI doc generation is now enabled for these APIs. 

### Functional changes
-  in the Cowrie Session API, when an invalid `include_credentials` parameter is passed, it now 400s instead of falling back to false
- errors are now returned in DRF's JSON error shape instead of plain text

These are braking changes, strictly speaking, but since they are only on authenticated endpoints and only touch error paths, I guess it's fine not to make a new major because of them. 

### Related issues

- #962

### Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

Please complete this checklist carefully. It helps guide your contribution and lets maintainers verify that all requirements are met.

### Formalities

- [x] I have read and understood the rules about [how to Contribute](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute) to this project.
- [x] I chose an appropriate title for the pull request in the form: `<feature name>. Closes #999`
- [x] My branch is based on `develop`.
- [x] The pull request is for the branch `develop`.
- [x] I have reviewed and verified any LLM-generated code included in this PR.

### Docs and tests

- [x] I documented my code changes with docstrings and/or comments.
- [x] I have checked if my changes affect user-facing behavior that is described in the [docs](https://github.com/GreedyBear-Project/GreedyBear/wiki). If so, I also included an update to the [wiki](https://github.com/GreedyBear-Project/GreedyBear/wiki) in the description of this PR.
- [x] Linter (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://github.com/GreedyBear-Project/GreedyBear/wiki/Contribute), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved.
- [x] All the tests gave 0 errors.

### GUI changes

Ignore this section if you did not make any changes to the GUI.

- [x] I have provided a screenshot of the result in the PR.
- [ ] I have created new frontend tests for the new component or updated existing ones.
  
# Review process

- We encourage you to create a draft PR first, even when your changes are incomplete. This way you refine your code while we can track your progress and actively review and help.
- If you think your draft PR is ready to be reviewed by the maintainers, click the corresponding button. Your draft PR will become a real PR.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem.
- Every time you make changes to the PR and you think the work is done, you should explicitly ask for a review. After receiving a "change request", address the feedback and click "request re-review" next to the reviewer's profile picture at the top right.
